### PR TITLE
feat: aplicar tema oscuro con efecto vidrio

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,104 +9,107 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <style>
     :root{
-      --ink:#0f241a; --ink-soft:#334155; --muted:#64748b; --bg:#ffffff;
-      --field:#f5f6f8; --field-focus:#ffffff; --border:#e6e7eb;
-      --pill-bg:#edf7f1; --pill-ink:#19603a; --btn:#222426; --btn-ink:#ffffff;
-      --ghost:#ffffff; --ghost-border:#dfe3e8; --ok:#16a34a; --warn:#f59e0b; --bad:#ef4444;
-      --link:#2563eb; --success:#166534; --danger:#b91c1c;
+      --ink:#f8fafc; --ink-soft:#e2e8f0; --muted:#94a3b8; --bg:#030712;
+      --field:rgba(15,23,42,.65); --field-focus:rgba(15,23,42,.78); --border:rgba(148,163,184,.35);
+      --pill-bg:rgba(37,99,235,.24); --pill-ink:#e0f2fe; --btn:#1d4ed8; --btn-ink:#f8fafc;
+      --ghost:rgba(15,23,42,.6); --ghost-border:rgba(148,163,184,.45); --ok:#4ade80; --warn:#facc15; --bad:#f87171;
+      --link:#60a5fa; --success:#22c55e; --danger:#f87171;
     }
-    *{box-sizing:border-box;font-family:Inter,ui-sans-serif,system-ui,Segoe UI,Roboto,Arial}
-    html,body{margin:0;background:var(--bg);color:var(--ink)}
-    a{color:inherit}
+    *{box-sizing:border-box;font-family:Inter,ui-sans-serif,system-ui,Segoe UI,Roboto,Arial;color-scheme:dark}
+    html,body{margin:0;background:radial-gradient(circle at 10% 10%,rgba(37,99,235,.24),transparent 55%),#030712;color:var(--ink)}
+    a{color:var(--link)}
 
     /* ===== Toolbar superior ===== */
-    .toolbar{position:sticky;top:0;z-index:40;background:rgba(255,255,255,.92);backdrop-filter:saturate(160%) blur(8px);border-bottom:1px solid var(--border)}
+    .toolbar{position:sticky;top:0;z-index:40;background:rgba(15,23,42,.72);backdrop-filter:saturate(160%) blur(12px);border-bottom:1px solid rgba(148,163,184,.35);box-shadow:0 12px 30px rgba(2,6,23,.45)}
     .toolbar-inner{max-width:980px;margin:0 auto;padding:10px 12px;display:flex;gap:8px;align-items:center}
-    .toolbar input,.toolbar select{padding:10px 12px;border-radius:10px;border:1px solid var(--ghost-border);background:#fff;min-width:200px}
+    .toolbar input,.toolbar select{padding:10px 12px;border-radius:12px;border:1px solid rgba(148,163,184,.4);background:rgba(15,23,42,.65);color:var(--ink);min-width:200px;backdrop-filter:blur(18px)}
+    .toolbar input::placeholder,.toolbar select option{color:var(--muted)}
     .spacer{flex:1}
-    .btn{border:0;border-radius:12px;padding:10px 14px;cursor:pointer;font-weight:600;transition:background-color .2s ease,border-color .2s ease,box-shadow .2s ease,transform .2s ease,color .2s ease}
-    .btn.ghost{background:var(--ghost);border:1px solid var(--ghost-border);}
-    .btn.primary{background:var(--btn);color:var(--btn-ink)}
-    .btn:hover,.btn:focus-visible{box-shadow:0 8px 16px rgba(15,36,26,.12);transform:translateY(-1px)}
-    .btn:active{transform:translateY(0);box-shadow:0 4px 10px rgba(15,36,26,.16)}
-    .btn.ghost:hover,.btn.ghost:focus-visible{background:#f8fafc;border-color:#cbd5e1}
-    .btn.ghost:active{background:#f1f5f9;border-color:#cbd5e1}
-    .btn.primary:hover,.btn.primary:focus-visible{background:#1b1d1f}
-    .btn.primary:active{background:#151719}
-    .btn:focus-visible{outline:2px solid rgba(37,99,235,.35);outline-offset:2px}
+    .btn{border:0;border-radius:14px;padding:10px 16px;cursor:pointer;font-weight:600;transition:background-color .2s ease,border-color .2s ease,box-shadow .2s ease,transform .2s ease,color .2s ease;color:var(--ink)}
+    .btn.ghost{background:var(--ghost);border:1px solid var(--ghost-border);color:var(--ink)}
+    .btn.primary{background:var(--btn);color:var(--btn-ink);box-shadow:0 10px 20px rgba(29,78,216,.35)}
+    .btn:hover,.btn:focus-visible{box-shadow:0 14px 28px rgba(15,23,42,.38);transform:translateY(-1px)}
+    .btn:active{transform:translateY(0);box-shadow:0 6px 14px rgba(15,23,42,.5)}
+    .btn.ghost:hover,.btn.ghost:focus-visible{background:rgba(30,41,59,.7);border-color:rgba(148,163,184,.6)}
+    .btn.ghost:active{background:rgba(30,41,59,.82);border-color:rgba(148,163,184,.65)}
+    .btn.primary:hover,.btn.primary:focus-visible{background:#1e40af}
+    .btn.primary:active{background:#1d3a9a}
+    .btn:focus-visible{outline:2px solid rgba(96,165,250,.6);outline-offset:3px}
     .linklike{background:none;border:0;color:var(--link);cursor:pointer;padding:0;font-weight:600;position:relative;transition:color .2s ease}
     .linklike::after{content:"";position:absolute;left:0;bottom:-2px;width:100%;height:2px;background:currentColor;transform:scaleX(0);transform-origin:left;transition:transform .2s ease}
-    .linklike:hover,.linklike:focus-visible{color:#1d4ed8}
+    .linklike:hover,.linklike:focus-visible{color:#93c5fd}
     .linklike:hover::after,.linklike:focus-visible::after{transform:scaleX(1)}
-    .linklike:active{color:#1e3a8a}
+    .linklike:active{color:#bfdbfe}
     .linklike:active::after{transform:scaleX(1)}
 
     /* ===== Layout ===== */
-    .wrap{max-width:980px;margin:0 auto;padding:28px 18px 60px}
-    .pill{display:block;width:max-content;margin:0 auto 10px;padding:6px 12px;border-radius:999px;background:var(--pill-bg);color:var(--pill-ink);border:1px solid #cfe7d8;font-size:12px}
-    h1{margin:6px 0 16px;text-align:center;font-weight:800;letter-spacing:-0.02em;color:var(--ink);font-size:clamp(36px,8vw,72px);line-height:1.02}
+    .wrap{max-width:980px;margin:32px auto;padding:32px 24px 64px;background:rgba(15,23,42,.55);backdrop-filter:blur(28px);border-radius:28px;border:1px solid rgba(148,163,184,.22);box-shadow:0 30px 60px rgba(2,6,23,.6)}
+    .pill{display:block;width:max-content;margin:0 auto 10px;padding:6px 12px;border-radius:999px;background:var(--pill-bg);color:var(--pill-ink);border:1px solid rgba(148,163,184,.4);font-size:12px;backdrop-filter:blur(18px)}
+    h1{margin:6px 0 16px;text-align:center;font-weight:800;letter-spacing:-0.02em;color:var(--ink);font-size:clamp(36px,8vw,72px);line-height:1.02;text-shadow:0 6px 18px rgba(2,6,23,.8)}
 
     /* ===== Servicio centrado ===== */
     .center{display:flex;justify-content:center;align-items:center;gap:10px;margin:8px 0 20px}
     .center .label{color:var(--ink-soft)}
-    .addserv{border:1px dashed var(--border);background:#fff;padding:8px 10px;border-radius:10px;font-size:14px;min-width:40px;text-align:center;transition:background-color .2s ease,border-color .2s ease,box-shadow .2s ease,transform .2s ease,color .2s ease}
-    .addserv:hover,.addserv:focus-visible{background:#f8fafc;border-color:#cbd5e1;box-shadow:0 6px 12px rgba(15,36,26,.08);transform:translateY(-1px)}
-    .addserv:active{background:#eef2f6;border-color:#cbd5e1;transform:translateY(0);box-shadow:0 3px 6px rgba(15,36,26,.12)}
-    .addserv:focus-visible{outline:2px solid rgba(37,99,235,.35);outline-offset:2px}
-    .addserv.remove{border-color:#fecaca;color:#7f1d1d}
+    .addserv{border:1px dashed rgba(148,163,184,.4);background:rgba(15,23,42,.6);padding:8px 10px;border-radius:12px;font-size:14px;min-width:40px;text-align:center;transition:background-color .2s ease,border-color .2s ease,box-shadow .2s ease,transform .2s ease,color .2s ease;color:var(--ink)}
+    .addserv:hover,.addserv:focus-visible{background:rgba(30,41,59,.72);border-color:rgba(148,163,184,.65);box-shadow:0 8px 18px rgba(15,23,42,.48);transform:translateY(-1px)}
+    .addserv:active{background:rgba(30,41,59,.82);border-color:rgba(148,163,184,.75);transform:translateY(0);box-shadow:0 4px 10px rgba(15,23,42,.58)}
+    .addserv:focus-visible{outline:2px solid rgba(96,165,250,.55);outline-offset:2px}
+    .addserv.remove{border-color:rgba(248,113,113,.6);color:#fecaca}
 
     /* ===== Form (labels arriba) ===== */
     .form{max-width:560px;margin:0 auto}
     .row{display:flex;flex-direction:column;gap:6px;margin-bottom:14px}
     .row label{color:var(--ink-soft);font-size:14px;font-weight:600}
-    input,select,textarea{width:100%;padding:14px;border:1px solid var(--border);border-radius:14px;background:var(--field);outline:none;transition:.15s}
-    input:focus,select:focus,textarea:focus{border-color:#cbd5e1;background:var(--field-focus);box-shadow:0 0 0 3px rgba(15, 23, 42, .05)}
+    input,select,textarea{width:100%;padding:14px;border:1px solid var(--border);border-radius:16px;background:var(--field);outline:none;transition:.15s;color:var(--ink)}
+    input::placeholder,textarea::placeholder{color:var(--muted)}
+    input:focus,select:focus,textarea:focus{border-color:rgba(96,165,250,.8);background:var(--field-focus);box-shadow:0 0 0 3px rgba(96,165,250,.25)}
     textarea{min-height:88px;resize:vertical}
     .actions{display:flex;justify-content:center;gap:10px;margin-top:18px}
     .small{font-size:12px;color:var(--muted);text-align:center;margin-top:8px}
     .pin-wrap{position:relative}
-    .pin-wrap .eye{position:absolute;right:10px;top:50%;transform:translateY(-50%);border:1px solid var(--ghost-border);background:#fff;border-radius:10px;padding:6px 8px;cursor:pointer}
+    .pin-wrap .eye{position:absolute;right:10px;top:50%;transform:translateY(-50%);border:1px solid rgba(148,163,184,.45);background:rgba(15,23,42,.7);border-radius:12px;padding:6px 8px;cursor:pointer;color:var(--ink)}
 
     /* ===== Tabla ===== */
-    .table-card{margin-top:26px;background:#fff;border-radius:18px;border:1px solid var(--ghost-border);box-shadow:0 18px 32px rgba(15,23,42,.06);overflow:hidden}
+    .table-card{margin-top:26px;background:rgba(15,23,42,.58);border-radius:22px;border:1px solid rgba(148,163,184,.25);box-shadow:0 24px 48px rgba(2,6,23,.7);overflow:hidden;backdrop-filter:blur(26px)}
     table{width:100%;border-collapse:collapse}
-    th,td{padding:14px 16px;border-bottom:1px solid var(--border);font-size:14px}
+    th,td{padding:14px 16px;border-bottom:1px solid rgba(148,163,184,.2);font-size:14px}
     th{text-align:left;color:var(--ink-soft);font-weight:700;letter-spacing:.01em;font-size:13px;text-transform:uppercase}
     td{color:var(--ink);font-weight:500}
     tbody tr{transition:background-color .2s ease,box-shadow .2s ease}
-    tbody tr:nth-child(even){background:#f8fafc}
-    tbody tr:hover{background:#eef2ff;box-shadow:inset 0 0 0 999px rgba(99,102,241,.08)}
+    tbody tr:nth-child(odd){background:rgba(15,23,42,.32)}
+    tbody tr:nth-child(even){background:rgba(30,41,59,.45)}
+    tbody tr:hover{background:rgba(30,64,175,.45);box-shadow:inset 0 0 0 999px rgba(30,64,175,.18)}
     .tag{font-size:12px;padding:3px 8px;border-radius:999px;display:inline-block;border:1px solid}
-    .tag.ok{color:#166534;background:#ecfdf5;border-color:#86efac}
-    .tag.warn{color:#92400e;background:#fffbeb;border-color:#fde68a}
-    .tag.bad{color:#7f1d1d;background:#fef2f2;border-color:#fecaca}
+    .tag.ok{color:#bbf7d0;background:rgba(34,197,94,.18);border-color:rgba(74,222,128,.35)}
+    .tag.warn{color:#fcd34d;background:rgba(250,204,21,.18);border-color:rgba(250,204,21,.35)}
+    .tag.bad{color:#fecaca;background:rgba(248,113,113,.18);border-color:rgba(248,113,113,.35)}
 
     /* ===== Kebab ⋯ menú ===== */
     .menu-wrap{position:relative;display:inline-block}
-    .kebab{border:1px solid var(--border);background:#fff;border-radius:12px;padding:6px 10px;cursor:pointer;line-height:1}
-    .kebab .dots{letter-spacing:2px;font-size:18px;color:#64748b}
-    .kebab:focus{outline:2px solid #cbd5e1}
-    .menu{position:absolute;right:0;top:calc(100% + 6px);background:#fff;border:1px solid var(--border);border-radius:12px;box-shadow:0 12px 28px rgba(2,6,23,.08);min-width:160px;padding:6px;opacity:0;visibility:hidden;pointer-events:none;transform:translateY(-6px);transition:opacity .2s ease,transform .2s ease;z-index:50}
+    .kebab{border:1px solid rgba(148,163,184,.4);background:rgba(15,23,42,.7);border-radius:12px;padding:6px 10px;cursor:pointer;line-height:1;color:var(--ink)}
+    .kebab .dots{letter-spacing:2px;font-size:18px;color:var(--muted)}
+    .kebab:focus{outline:2px solid rgba(96,165,250,.55)}
+    .menu{position:absolute;right:0;top:calc(100% + 6px);background:rgba(15,23,42,.92);border:1px solid rgba(148,163,184,.35);border-radius:16px;box-shadow:0 16px 36px rgba(2,6,23,.7);min-width:180px;padding:8px;opacity:0;visibility:hidden;pointer-events:none;transform:translateY(-6px);transition:opacity .2s ease,transform .2s ease;z-index:50;backdrop-filter:blur(18px)}
     .menu.open{opacity:1;visibility:visible;pointer-events:auto;transform:translateY(0)}
-    .menu-item{display:block;width:100%;text-align:left;background:#fff;border:0;border-radius:8px;padding:9px 10px;cursor:pointer;font-size:14px}
-    .menu-item:hover{background:#f3f4f6}
-    .menu-item.danger{color:#7f1d1d;border:1px solid #fecaca}
+    .menu-item{display:block;width:100%;text-align:left;background:transparent;border:0;border-radius:10px;padding:10px 12px;cursor:pointer;font-size:14px;color:var(--ink)}
+    .menu-item:hover{background:rgba(96,165,250,.18)}
+    .menu-item.danger{color:#fecaca;border:1px solid rgba(248,113,113,.4)}
 
     /* ===== Modales ===== */
-    .modal-backdrop{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;padding:16px;background:rgba(2,6,23,.45);opacity:0;visibility:hidden;pointer-events:none;transform:translateY(6px);transition:opacity .2s ease,transform .2s ease;z-index:100}
+    .modal-backdrop{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;padding:16px;background:rgba(2,6,23,.65);opacity:0;visibility:hidden;pointer-events:none;transform:translateY(6px);transition:opacity .2s ease,transform .2s ease;z-index:100}
     .modal-backdrop.open{opacity:1;visibility:visible;pointer-events:auto;transform:translateY(0)}
-    .modal{background:#fff;border:1px solid var(--border);border-radius:16px;width:min(760px,96vw);max-height:90vh;display:flex;flex-direction:column}
-    .modal header{display:flex;align-items:center;justify-content:space-between;padding:12px 14px;border-bottom:1px solid var(--border)}
+    .modal{background:rgba(15,23,42,.85);border:1px solid rgba(148,163,184,.35);border-radius:22px;width:min(760px,96vw);max-height:90vh;display:flex;flex-direction:column;backdrop-filter:blur(28px);box-shadow:0 28px 60px rgba(2,6,23,.75)}
+    .modal header{display:flex;align-items:center;justify-content:space-between;padding:12px 14px;border-bottom:1px solid rgba(148,163,184,.25)}
     .modal .body{padding:12px}
 
     /* ===== Chat (Gemini) ===== */
     .section-head{font-weight:700;margin-bottom:8px;color:var(--ink)}
-    .chat-log{height:260px;overflow:auto;border:1px solid var(--border);border-radius:12px;padding:10px;background:#f9fafb}
+    .chat-log{height:260px;overflow:auto;border:1px solid rgba(148,163,184,.35);border-radius:16px;padding:12px;background:rgba(15,23,42,.6);backdrop-filter:blur(18px)}
     .chat-msg{margin:8px 0;display:flex}
     .chat-msg.user{justify-content:flex-end}
     .chat-msg .bubble{max-width:85%;padding:10px 12px;border-radius:12px;white-space:pre-wrap}
-    .chat-msg.user .bubble{background:#111827;color:#fff;border:1px solid #0b1220}
-    .chat-msg.ai .bubble{background:#fff;border:1px solid var(--border);color:#0b1f16}
+    .chat-msg.user .bubble{background:rgba(37,99,235,.7);color:#e0f2fe;border:1px solid rgba(59,130,246,.5);box-shadow:0 10px 20px rgba(37,99,235,.35)}
+    .chat-msg.ai .bubble{background:rgba(15,23,42,.75);border:1px solid rgba(148,163,184,.3);color:var(--ink)}
 
     @media (max-width:680px){ .toolbar-inner{flex-wrap:wrap} }
   </style>


### PR DESCRIPTION
## Summary
- redefine la paleta CSS para un tema oscuro con alto contraste
- aplica fondos semitransparentes con blur y bordes suaves para toolbar, formulario, tablas y modales
- ajusta botones, etiquetas y tablas para mantener legibilidad AA sobre el nuevo fondo

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfb3faff5083269e38a9f5c622a99c