### PR TITLE
Restyle UI with dark glassmorphism theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,58 +9,64 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <style>
     :root{
-      --ink:#0f241a; --ink-soft:#334155; --muted:#64748b; --bg:#ffffff;
-      --field:#f5f6f8; --field-focus:#ffffff; --border:#e6e7eb;
-      --pill-bg:#edf7f1; --pill-ink:#19603a; --btn:#222426; --btn-ink:#ffffff;
-      --ghost:#ffffff; --ghost-border:#dfe3e8; --ok:#16a34a; --warn:#f59e0b; --bad:#ef4444;
-      --link:#2563eb; --success:#166534; --danger:#b91c1c;
+      --bg:#050608; --ink:#f8fafc; --ink-soft:#d2d9e6; --muted:#9aa7bb;
+      --field:rgba(14,18,26,.85); --field-focus:rgba(20,26,36,.92); --border:rgba(255,255,255,.12);
+      --pill-bg:rgba(249,115,22,.18); --pill-ink:#ffd7a3; --btn:#f28a2d; --btn-ink:#1c130a;
+      --ghost:rgba(255,255,255,.06); --ghost-border:rgba(255,255,255,.18);
+      --ok:#4ade80; --warn:#fbbf24; --bad:#fb7185; --link:#7dd3fc;
+      --success:#16f2a6; --danger:#f97373; --shadow:0 30px 60px rgba(3,6,10,.55);
     }
     *{box-sizing:border-box;font-family:Inter,ui-sans-serif,system-ui,Segoe UI,Roboto,Arial}
-    html,body{margin:0;background:var(--bg);color:var(--ink)}
+    html,body{margin:0;min-height:100%;background:var(--bg);color:var(--ink)}
+    body{position:relative;min-height:100vh;overflow-x:hidden}
+    body::before{content:"";position:fixed;inset:-40%;background:radial-gradient(circle at 20% 20%,rgba(242,138,45,.18),rgba(15,20,28,0) 45%),radial-gradient(circle at 80% 10%,rgba(125,211,252,.14),rgba(5,6,8,0) 52%),radial-gradient(circle at 30% 80%,rgba(22,242,166,.1),rgba(5,6,8,0) 55%);pointer-events:none;z-index:-1;filter:blur(0px)}
     a{color:inherit}
 
     /* ===== Toolbar superior ===== */
-    .toolbar{position:sticky;top:0;z-index:40;background:rgba(255,255,255,.92);backdrop-filter:saturate(160%) blur(8px);border-bottom:1px solid var(--border)}
-    .toolbar-inner{max-width:980px;margin:0 auto;padding:10px 12px;display:flex;gap:8px;align-items:center}
-    .toolbar input,.toolbar select{padding:10px 12px;border-radius:10px;border:1px solid var(--ghost-border);background:#fff;min-width:200px}
+    .toolbar{position:sticky;top:0;z-index:40;background:rgba(6,9,15,.82);backdrop-filter:saturate(160%) blur(16px);border-bottom:1px solid var(--border);box-shadow:var(--shadow)}
+    .toolbar-inner{max-width:980px;margin:0 auto;padding:12px 16px;display:flex;gap:10px;align-items:center}
+    .toolbar input,.toolbar select{padding:10px 12px;border-radius:12px;border:1px solid var(--border);background:rgba(255,255,255,.05);color:var(--ink);min-width:200px;box-shadow:inset 0 1px 0 rgba(255,255,255,.04)}
+    .toolbar input::placeholder{color:var(--muted)}
+    .toolbar select{color:var(--ink)}
+    .toolbar select option{color:#0f172a;background:#e2e8f0}
     .spacer{flex:1}
-    .btn{border:0;border-radius:12px;padding:10px 14px;cursor:pointer;font-weight:600;transition:background-color .2s ease,border-color .2s ease,box-shadow .2s ease,transform .2s ease,color .2s ease}
-    .btn.ghost{background:var(--ghost);border:1px solid var(--ghost-border);}
-    .btn.primary{background:var(--btn);color:var(--btn-ink)}
-    .btn:hover,.btn:focus-visible{box-shadow:0 8px 16px rgba(15,36,26,.12);transform:translateY(-1px)}
-    .btn:active{transform:translateY(0);box-shadow:0 4px 10px rgba(15,36,26,.16)}
-    .btn.ghost:hover,.btn.ghost:focus-visible{background:#f8fafc;border-color:#cbd5e1}
-    .btn.ghost:active{background:#f1f5f9;border-color:#cbd5e1}
-    .btn.primary:hover,.btn.primary:focus-visible{background:#1b1d1f}
-    .btn.primary:active{background:#151719}
-    .btn:focus-visible{outline:2px solid rgba(37,99,235,.35);outline-offset:2px}
+    .btn{border:0;border-radius:14px;padding:10px 16px;cursor:pointer;font-weight:600;transition:background-color .2s ease,border-color .2s ease,box-shadow .2s ease,transform .2s ease,color .2s ease;color:var(--ink)}
+    .btn.ghost{background:var(--ghost);border:1px solid var(--ghost-border);box-shadow:inset 0 1px 0 rgba(255,255,255,.05)}
+    .btn.primary{background:var(--btn);color:var(--btn-ink);box-shadow:0 12px 24px rgba(242,138,45,.35)}
+    .btn:hover,.btn:focus-visible{box-shadow:0 14px 28px rgba(5,9,15,.45);transform:translateY(-1px)}
+    .btn:active{transform:translateY(0);box-shadow:0 6px 12px rgba(5,9,15,.6)}
+    .btn.ghost:hover,.btn.ghost:focus-visible{background:rgba(255,255,255,.12);border-color:rgba(255,255,255,.26)}
+    .btn.ghost:active{background:rgba(255,255,255,.18);border-color:rgba(255,255,255,.32)}
+    .btn.primary:hover,.btn.primary:focus-visible{background:#ffa24d}
+    .btn.primary:active{background:#f28a2d}
+    .btn:focus-visible{outline:2px solid rgba(125,211,252,.45);outline-offset:3px}
     .linklike{background:none;border:0;color:var(--link);cursor:pointer;padding:0;font-weight:600;position:relative;transition:color .2s ease}
     .linklike::after{content:"";position:absolute;left:0;bottom:-2px;width:100%;height:2px;background:currentColor;transform:scaleX(0);transform-origin:left;transition:transform .2s ease}
-    .linklike:hover,.linklike:focus-visible{color:#1d4ed8}
+    .linklike:hover,.linklike:focus-visible{color:#bae6fd}
     .linklike:hover::after,.linklike:focus-visible::after{transform:scaleX(1)}
-    .linklike:active{color:#1e3a8a}
+    .linklike:active{color:#38bdf8}
     .linklike:active::after{transform:scaleX(1)}
 
     /* ===== Layout ===== */
-    .wrap{width:min(1200px,92vw);margin:0 auto;padding:28px 18px 60px}
-    .pill{display:block;width:max-content;margin:0 auto 10px;padding:6px 12px;border-radius:999px;background:var(--pill-bg);color:var(--pill-ink);border:1px solid #cfe7d8;font-size:12px}
-    h1{margin:6px 0 16px;text-align:center;font-weight:800;letter-spacing:-0.02em;color:var(--ink);font-size:clamp(36px,8vw,72px);line-height:1.02}
+    .wrap{width:min(1200px,92vw);margin:0 auto;padding:36px 18px 80px;position:relative;z-index:0}
+    .pill{display:block;width:max-content;margin:0 auto 14px;padding:6px 14px;border-radius:999px;background:var(--pill-bg);color:var(--pill-ink);border:1px solid rgba(255,255,255,.24);font-size:12px;letter-spacing:.08em;text-transform:uppercase}
+    h1{margin:6px 0 20px;text-align:center;font-weight:800;letter-spacing:-0.02em;color:var(--ink);font-size:clamp(36px,8vw,72px);line-height:1.02;text-shadow:0 12px 32px rgba(0,0,0,.55)}
 
     /* ===== Servicio centrado ===== */
     .center{display:flex;justify-content:center;align-items:center;gap:10px;margin:8px 0 20px}
     .center .label{color:var(--ink-soft)}
-    .addserv{border:1px dashed var(--border);background:#fff;padding:8px 10px;border-radius:10px;font-size:14px;min-width:40px;text-align:center;transition:background-color .2s ease,border-color .2s ease,box-shadow .2s ease,transform .2s ease,color .2s ease}
-    .addserv:hover,.addserv:focus-visible{background:#f8fafc;border-color:#cbd5e1;box-shadow:0 6px 12px rgba(15,36,26,.08);transform:translateY(-1px)}
-    .addserv:active{background:#eef2f6;border-color:#cbd5e1;transform:translateY(0);box-shadow:0 3px 6px rgba(15,36,26,.12)}
-    .addserv:focus-visible{outline:2px solid rgba(37,99,235,.35);outline-offset:2px}
-    .addserv.remove{border-color:#fecaca;color:#7f1d1d}
+    .addserv{border:1px dashed rgba(255,255,255,.26);background:rgba(255,255,255,.04);color:var(--ink);padding:8px 12px;border-radius:12px;font-size:15px;min-width:40px;text-align:center;transition:background-color .2s ease,border-color .2s ease,box-shadow .2s ease,transform .2s ease,color .2s ease}
+    .addserv:hover,.addserv:focus-visible{background:rgba(242,138,45,.16);border-color:rgba(242,138,45,.4);box-shadow:0 10px 24px rgba(5,9,15,.4);transform:translateY(-1px)}
+    .addserv:active{background:rgba(242,138,45,.24);border-color:rgba(242,138,45,.5);transform:translateY(0);box-shadow:0 6px 16px rgba(5,9,15,.6)}
+    .addserv:focus-visible{outline:2px solid rgba(242,138,45,.35);outline-offset:2px}
+    .addserv.remove{border-color:rgba(251,113,133,.45);color:#fecdd3;background:rgba(248,113,113,.16)}
 
     /* ===== Form (labels arriba) ===== */
     .content-grid{display:grid;gap:24px;margin-top:32px}
     @media(min-width:960px){
       .content-grid{grid-template-columns:minmax(0,2fr)minmax(0,1fr)}
     }
-    .form{background:#fff;border-radius:18px;border:1px solid var(--ghost-border);padding:24px;box-shadow:0 18px 32px rgba(15,23,42,.04)}
+    .form{background:rgba(255,255,255,.06);border-radius:20px;border:1px solid var(--border);padding:28px;box-shadow:var(--shadow);backdrop-filter:blur(22px)}
     .form-grid{display:grid;gap:16px}
     @media(min-width:720px){
       .form-grid{grid-template-columns:repeat(2,minmax(0,1fr))}
@@ -68,20 +74,23 @@
     .row{display:flex;flex-direction:column;gap:6px}
     .form-grid .row{min-width:0}
     .span-2{grid-column:1 / -1}
-    .row label{color:var(--ink-soft);font-size:14px;font-weight:600}
-    input,select,textarea{width:100%;padding:14px;border:1px solid var(--border);border-radius:14px;background:var(--field);outline:none;transition:.15s}
-    input:focus,select:focus,textarea:focus{border-color:#cbd5e1;background:var(--field-focus);box-shadow:0 0 0 3px rgba(15, 23, 42, .05)}
+    .row label{color:var(--ink-soft);font-size:13px;font-weight:600;letter-spacing:.04em;text-transform:uppercase}
+    input,select,textarea{width:100%;padding:14px;border:1px solid rgba(255,255,255,.14);border-radius:14px;background:var(--field);color:var(--ink);outline:none;transition:.15s;box-shadow:inset 0 1px 0 rgba(255,255,255,.06)}
+    input::placeholder,textarea::placeholder{color:var(--muted)}
+    input:focus,select:focus,textarea:focus{border-color:rgba(125,211,252,.6);background:var(--field-focus);box-shadow:0 0 0 3px rgba(125,211,252,.2)}
     textarea{min-height:88px;resize:vertical}
     .actions{display:flex;justify-content:center;gap:10px;margin-top:18px}
     .small{font-size:12px;color:var(--muted);text-align:center;margin-top:8px}
-    .side-card{background:#fff;border-radius:18px;border:1px solid var(--ghost-border);padding:24px;box-shadow:0 18px 32px rgba(15,23,42,.04);display:flex;flex-direction:column;gap:18px}
+    .side-card{background:rgba(255,255,255,.06);border-radius:20px;border:1px solid var(--border);padding:28px;box-shadow:var(--shadow);backdrop-filter:blur(22px);display:flex;flex-direction:column;gap:18px}
     .side-card h2{margin:0;font-size:18px;color:var(--ink);font-weight:700}
     .side-card p{margin:0;color:var(--muted);font-size:14px}
     .side-card .actions{flex-direction:column;justify-content:flex-start}
     .side-card .actions .btn{width:100%}
     .side-card .small{text-align:left;margin-top:0}
     .pin-wrap{position:relative}
-    .pin-wrap .eye{position:absolute;right:10px;top:50%;transform:translateY(-50%);border:1px solid var(--ghost-border);background:#fff;border-radius:10px;padding:6px 8px;cursor:pointer}
+    .pin-wrap .eye{position:absolute;right:10px;top:50%;transform:translateY(-50%);border:1px solid rgba(255,255,255,.18);background:rgba(255,255,255,.08);color:var(--ink);border-radius:10px;padding:6px 8px;cursor:pointer;transition:background-color .2s ease,border-color .2s ease}
+    .pin-wrap .eye:hover,.pin-wrap .eye:focus-visible{background:rgba(255,255,255,.18);border-color:rgba(255,255,255,.28)}
+    .pin-wrap .eye:focus-visible{outline:2px solid rgba(125,211,252,.35);outline-offset:2px}
 
     /* ===== Tabla ===== */
     .table-section{margin-top:40px;display:flex;flex-direction:column;gap:18px}
@@ -89,47 +98,49 @@
     @media(min-width:720px){
       .table-header{flex-direction:row;align-items:flex-end;justify-content:space-between}
     }
-    .table-header h2{margin:0;font-size:22px;font-weight:700;color:var(--ink)}
+    .table-header h2{margin:0;font-size:22px;font-weight:700;color:var(--ink);text-shadow:0 10px 20px rgba(0,0,0,.35)}
     .table-header p{margin:0;color:var(--muted);font-size:14px}
-    .table-card{background:#fff;border-radius:18px;border:1px solid var(--ghost-border);box-shadow:0 18px 32px rgba(15,23,42,.06);overflow:hidden}
+    .table-card{background:rgba(255,255,255,.05);border-radius:20px;border:1px solid var(--border);box-shadow:var(--shadow);overflow:hidden;backdrop-filter:blur(18px)}
     table{width:100%;border-collapse:collapse}
-    th,td{padding:14px 16px;border-bottom:1px solid var(--border);font-size:14px}
-    th{text-align:left;color:var(--ink-soft);font-weight:700;letter-spacing:.01em;font-size:13px;text-transform:uppercase}
+    th,td{padding:14px 16px;border-bottom:1px solid rgba(255,255,255,.08);font-size:14px}
+    th{text-align:left;color:var(--muted);font-weight:700;letter-spacing:.08em;font-size:12px;text-transform:uppercase}
     td{color:var(--ink);font-weight:500}
     tbody tr{transition:background-color .2s ease,box-shadow .2s ease}
-    tbody tr:nth-child(even){background:#f8fafc}
-    tbody tr:hover{background:#eef2ff;box-shadow:inset 0 0 0 999px rgba(99,102,241,.08)}
-    .tag{font-size:12px;padding:3px 8px;border-radius:999px;display:inline-block;border:1px solid}
-    .tag.ok{color:#166534;background:#ecfdf5;border-color:#86efac}
-    .tag.warn{color:#92400e;background:#fffbeb;border-color:#fde68a}
-    .tag.bad{color:#7f1d1d;background:#fef2f2;border-color:#fecaca}
+    tbody tr:nth-child(even){background:rgba(255,255,255,.03)}
+    tbody tr:hover{background:rgba(125,211,252,.12);box-shadow:inset 0 0 0 999px rgba(5,9,15,.12)}
+    .tag{font-size:12px;padding:4px 10px;border-radius:999px;display:inline-block;border:1px solid rgba(255,255,255,.2);background:rgba(255,255,255,.05);color:var(--ink);backdrop-filter:blur(12px)}
+    .tag.ok{color:var(--ok);background:rgba(74,222,128,.16);border-color:rgba(74,222,128,.38)}
+    .tag.warn{color:var(--warn);background:rgba(251,191,36,.16);border-color:rgba(251,191,36,.38)}
+    .tag.bad{color:var(--bad);background:rgba(251,113,133,.2);border-color:rgba(251,113,133,.4)}
 
     /* ===== Kebab ⋯ menú ===== */
     .menu-wrap{position:relative;display:inline-block}
-    .kebab{border:1px solid var(--border);background:#fff;border-radius:12px;padding:6px 10px;cursor:pointer;line-height:1}
-    .kebab .dots{letter-spacing:2px;font-size:18px;color:#64748b}
-    .kebab:focus{outline:2px solid #cbd5e1}
-    .menu{position:absolute;right:0;top:calc(100% + 6px);background:#fff;border:1px solid var(--border);border-radius:12px;box-shadow:0 12px 28px rgba(2,6,23,.08);min-width:160px;padding:6px;opacity:0;visibility:hidden;pointer-events:none;transform:translateY(-6px);transition:opacity .2s ease,transform .2s ease;z-index:50}
+    .kebab{border:1px solid rgba(255,255,255,.18);background:rgba(255,255,255,.05);border-radius:12px;padding:6px 10px;cursor:pointer;line-height:1;color:var(--ink);transition:background-color .2s ease,border-color .2s ease}
+    .kebab .dots{letter-spacing:2px;font-size:18px;color:var(--ink-soft)}
+    .kebab:focus{outline:2px solid rgba(125,211,252,.35)}
+    .kebab:hover{background:rgba(255,255,255,.12);border-color:rgba(255,255,255,.28)}
+    .menu{position:absolute;right:0;top:calc(100% + 8px);background:rgba(10,14,22,.96);border:1px solid var(--border);border-radius:14px;box-shadow:var(--shadow);min-width:180px;padding:8px;opacity:0;visibility:hidden;pointer-events:none;transform:translateY(-6px);transition:opacity .2s ease,transform .2s ease;z-index:50;backdrop-filter:blur(18px)}
     .menu.open{opacity:1;visibility:visible;pointer-events:auto;transform:translateY(0)}
-    .menu-item{display:block;width:100%;text-align:left;background:#fff;border:0;border-radius:8px;padding:9px 10px;cursor:pointer;font-size:14px}
-    .menu-item:hover{background:#f3f4f6}
-    .menu-item.danger{color:#7f1d1d;border:1px solid #fecaca}
+    .menu-item{display:block;width:100%;text-align:left;background:transparent;border:0;border-radius:10px;padding:10px 12px;cursor:pointer;font-size:14px;color:var(--ink);transition:background-color .15s ease,border-color .15s ease,color .15s ease}
+    .menu-item:hover{background:rgba(255,255,255,.08)}
+    .menu-item.danger{color:var(--bad);border:1px solid rgba(251,113,133,.35);background:rgba(251,113,133,.12)}
+    .menu-item.danger:hover{background:rgba(251,113,133,.2);border-color:rgba(251,113,133,.5)}
 
     /* ===== Modales ===== */
-    .modal-backdrop{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;padding:16px;background:rgba(2,6,23,.45);opacity:0;visibility:hidden;pointer-events:none;transform:translateY(6px);transition:opacity .2s ease,transform .2s ease;z-index:100}
+    .modal-backdrop{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;padding:16px;background:rgba(3,6,11,.78);opacity:0;visibility:hidden;pointer-events:none;transform:translateY(6px);transition:opacity .2s ease,transform .2s ease;z-index:100;backdrop-filter:blur(12px)}
     .modal-backdrop.open{opacity:1;visibility:visible;pointer-events:auto;transform:translateY(0)}
-    .modal{background:#fff;border:1px solid var(--border);border-radius:16px;width:min(760px,96vw);max-height:90vh;display:flex;flex-direction:column}
-    .modal header{display:flex;align-items:center;justify-content:space-between;padding:12px 14px;border-bottom:1px solid var(--border)}
-    .modal .body{padding:12px}
+    .modal{background:rgba(10,14,22,.92);border:1px solid var(--border);border-radius:18px;width:min(760px,96vw);max-height:90vh;display:flex;flex-direction:column;box-shadow:var(--shadow);color:var(--ink);backdrop-filter:blur(22px)}
+    .modal header{display:flex;align-items:center;justify-content:space-between;padding:16px 18px;border-bottom:1px solid rgba(255,255,255,.08)}
+    .modal .body{padding:16px 18px;color:var(--ink)}
 
     /* ===== Chat (Gemini) ===== */
-    .section-head{font-weight:700;margin-bottom:8px;color:var(--ink)}
-    .chat-log{height:260px;overflow:auto;border:1px solid var(--border);border-radius:12px;padding:10px;background:#f9fafb}
+    .section-head{font-weight:700;margin-bottom:8px;color:var(--ink);text-shadow:0 10px 24px rgba(0,0,0,.45)}
+    .chat-log{height:260px;overflow:auto;border:1px solid var(--border);border-radius:16px;padding:14px;background:rgba(255,255,255,.05);box-shadow:inset 0 1px 0 rgba(255,255,255,.04);backdrop-filter:blur(14px)}
     .chat-msg{margin:8px 0;display:flex}
     .chat-msg.user{justify-content:flex-end}
     .chat-msg .bubble{max-width:85%;padding:10px 12px;border-radius:12px;white-space:pre-wrap}
-    .chat-msg.user .bubble{background:#111827;color:#fff;border:1px solid #0b1220}
-    .chat-msg.ai .bubble{background:#fff;border:1px solid var(--border);color:#0b1f16}
+    .chat-msg.user .bubble{background:linear-gradient(135deg,#f28a2d,#f59e0b);color:#1a1205;border:1px solid rgba(255,255,255,.18);box-shadow:0 14px 32px rgba(242,138,45,.35)}
+    .chat-msg.ai .bubble{background:rgba(15,20,28,.92);border:1px solid rgba(255,255,255,.12);color:var(--ink);box-shadow:0 10px 24px rgba(0,0,0,.4)}
 
     @media (max-width:680px){ .toolbar-inner{flex-wrap:wrap} }
   </style>


### PR DESCRIPTION
## Summary
- switch the design system to a carbon-inspired palette with warm accents and a radial glow backdrop
- refresh toolbars, forms, tables, modals and chat bubbles with translucent surfaces, subtle borders and updated focus states for contrast
- align status tags, pills and interactive controls to the new dark theme while preserving readability for all states

## Testing
- not run (static HTML page)


------
https://chatgpt.com/codex/tasks/task_e_68cfb7045d208326a6f48cea352d09a5