### PR TITLE
Adjust background to pure black

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <style>
     :root{
-      --bg:#050608; --ink:#f8fafc; --ink-soft:#d2d9e6; --muted:#9aa7bb;
+      --bg:#000000; --ink:#f8fafc; --ink-soft:#d2d9e6; --muted:#9aa7bb;
       --field:rgba(14,18,26,.85); --field-focus:rgba(20,26,36,.92); --border:rgba(255,255,255,.12);
       --pill-bg:rgba(249,115,22,.18); --pill-ink:#ffd7a3; --btn:#f28a2d; --btn-ink:#1c130a;
       --ghost:rgba(255,255,255,.06); --ghost-border:rgba(255,255,255,.18);
@@ -19,7 +19,7 @@
     *{box-sizing:border-box;font-family:Inter,ui-sans-serif,system-ui,Segoe UI,Roboto,Arial}
     html,body{margin:0;min-height:100%;background:var(--bg);color:var(--ink)}
     body{position:relative;min-height:100vh;overflow-x:hidden}
-    body::before{content:"";position:fixed;inset:-40%;background:radial-gradient(circle at 20% 20%,rgba(242,138,45,.18),rgba(15,20,28,0) 45%),radial-gradient(circle at 80% 10%,rgba(125,211,252,.14),rgba(5,6,8,0) 52%),radial-gradient(circle at 30% 80%,rgba(22,242,166,.1),rgba(5,6,8,0) 55%);pointer-events:none;z-index:-1;filter:blur(0px)}
+    body::before{content:"";position:fixed;inset:-40%;background:radial-gradient(circle at 20% 20%,rgba(242,138,45,.08),rgba(0,0,0,0) 45%),radial-gradient(circle at 80% 10%,rgba(125,211,252,.06),rgba(0,0,0,0) 52%),radial-gradient(circle at 30% 80%,rgba(22,242,166,.04),rgba(0,0,0,0) 55%);pointer-events:none;z-index:-1;filter:blur(0px)}
     a{color:inherit}
 
     /* ===== Toolbar superior ===== */


### PR DESCRIPTION
## Summary
- set the global background color variable to pure black and keep the rest of the palette intact
- soften the body overlay gradients so the page retains a black appearance while preserving subtle lighting

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cfba44aa5c8326aa31b63b03343d3f