### PR TITLE
Ocultar insignia importante del encabezado

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@
   </div>
 
   <div class="wrap">
-    <span class="pill">importante</span>
+    <!-- <span class="pill">importante</span> -->
     <h1>Zyl0</h1>
 
     <div class="center">


### PR DESCRIPTION
## Summary
- comentar la línea del distintivo "importante" dentro del contenedor principal para ocultarlo
- mantener los estilos de `.pill` ya que la clase también se utiliza en el elemento `#userInfo`

## Testing
- no se realizaron pruebas automatizadas; no aplica

------
https://chatgpt.com/codex/tasks/task_e_68cfbc2b8c24832692a4bf94da52697c