### PR TITLE
Allow table card menus to overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,14 +100,19 @@
     }
     .table-header h2{margin:0;font-size:22px;font-weight:700;color:var(--ink);text-shadow:0 10px 20px rgba(0,0,0,.35)}
     .table-header p{margin:0;color:var(--muted);font-size:14px}
-    .table-card{background:rgba(255,255,255,.05);border-radius:20px;border:1px solid var(--border);box-shadow:var(--shadow);overflow:hidden;backdrop-filter:blur(18px)}
-    table{width:100%;border-collapse:collapse}
+    .table-card{position:relative;background:rgba(255,255,255,.05);border-radius:20px;border:1px solid var(--border);box-shadow:var(--shadow);overflow:visible;backdrop-filter:blur(18px)}
+    table{width:100%;border-collapse:separate;border-spacing:0;border-radius:inherit}
     th,td{padding:14px 16px;border-bottom:1px solid rgba(255,255,255,.08);font-size:14px}
     th{text-align:left;color:var(--muted);font-weight:700;letter-spacing:.08em;font-size:12px;text-transform:uppercase}
     td{color:var(--ink);font-weight:500}
     tbody tr{transition:background-color .2s ease,box-shadow .2s ease}
     tbody tr:nth-child(even){background:rgba(255,255,255,.03)}
     tbody tr:hover{background:rgba(125,211,252,.12);box-shadow:inset 0 0 0 999px rgba(5,9,15,.12)}
+    thead th:first-child{border-top-left-radius:20px}
+    thead th:last-child{border-top-right-radius:20px}
+    tbody tr:last-child td:first-child{border-bottom-left-radius:20px}
+    tbody tr:last-child td:last-child{border-bottom-right-radius:20px}
+    .table-card th,.table-card td{background-clip:padding-box}
     .tag{font-size:12px;padding:4px 10px;border-radius:999px;display:inline-block;border:1px solid rgba(255,255,255,.2);background:rgba(255,255,255,.05);color:var(--ink);backdrop-filter:blur(12px)}
     .tag.ok{color:var(--ok);background:rgba(74,222,128,.16);border-color:rgba(74,222,128,.38)}
     .tag.warn{color:var(--warn);background:rgba(251,191,36,.16);border-color:rgba(251,191,36,.38)}


### PR DESCRIPTION
## Summary
- let the table card surface use visible overflow so the action menu can extend outside the card
- round the header and footer cells so the table keeps its curved corners without clipping the dropdown

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfc4e6b6fc832694af0e67b6eda626