### PR TITLE
Refactor sidebar layout and behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
     }
     *{box-sizing:border-box;font-family:Inter,ui-sans-serif,system-ui,Segoe UI,Roboto,Arial}
     html,body{margin:0;min-height:100%;background:var(--bg);color:var(--ink)}
-    body{position:relative;min-height:100vh;overflow-x:hidden}
+    body{position:relative;min-height:100vh;overflow-x:hidden;padding-left:72px;transition:padding-left .3s ease}
     body::before{content:"";position:fixed;inset:-40%;background:radial-gradient(circle at 20% 20%,rgba(242,138,45,.08),rgba(0,0,0,0) 45%),radial-gradient(circle at 80% 10%,rgba(125,211,252,.06),rgba(0,0,0,0) 52%),radial-gradient(circle at 30% 80%,rgba(22,242,166,.04),rgba(0,0,0,0) 55%);pointer-events:none;z-index:-1;filter:blur(0px)}
     body.theme-light{
       color-scheme:light;
@@ -95,14 +95,25 @@
     }
     a{color:inherit}
 
-    /* ===== Toolbar superior ===== */
-    .toolbar{position:sticky;top:0;z-index:40;background:rgba(6,9,15,.82);backdrop-filter:saturate(160%) blur(16px);border-bottom:1px solid var(--border);box-shadow:var(--shadow)}
-    .toolbar-inner{max-width:980px;margin:0 auto;padding:12px 16px;display:flex;gap:10px;align-items:center}
-    .toolbar input,.toolbar select{padding:10px 12px;border-radius:12px;border:1px solid var(--border);background:rgba(255,255,255,.05);color:var(--ink);min-width:200px;box-shadow:inset 0 1px 0 rgba(255,255,255,.04)}
-    .toolbar input::placeholder{color:var(--muted)}
-    .toolbar select{color:var(--ink)}
-    .toolbar select option{color:#0f172a;background:#e2e8f0}
-    .spacer{flex:1}
+    body.sidebar-expanded{padding-left:260px}
+    /* ===== Header y sidebar ===== */
+    .app-header{position:sticky;top:0;z-index:40;display:flex;align-items:center;gap:12px;padding:12px 16px;background:var(--toolbar-bg);border-bottom:1px solid var(--border);backdrop-filter:saturate(160%) blur(16px);box-shadow:var(--shadow)}
+    .sidebar-toggle{position:relative;width:44px;height:44px;border-radius:12px;border:1px solid transparent;background:transparent;color:var(--ink);cursor:pointer;display:flex;align-items:center;justify-content:center;transition:background-color .2s ease,border-color .2s ease}
+    .sidebar-toggle span{position:absolute;width:20px;height:2px;background:currentColor;border-radius:2px;transition:transform .25s ease,opacity .25s ease,top .25s ease}
+    .sidebar-toggle span:nth-child(1){top:16px}
+    .sidebar-toggle span:nth-child(2){top:21px}
+    .sidebar-toggle span:nth-child(3){top:26px}
+    .sidebar-toggle:hover,.sidebar-toggle:focus-visible{background:rgba(255,255,255,.08);border-color:rgba(255,255,255,.18)}
+    .sidebar-toggle:focus-visible{outline:2px solid rgba(125,211,252,.35);outline-offset:2px}
+    .sidebar-toggle.is-open span:nth-child(1){top:21px;transform:rotate(45deg)}
+    .sidebar-toggle.is-open span:nth-child(2){opacity:0}
+    .sidebar-toggle.is-open span:nth-child(3){top:21px;transform:rotate(-45deg)}
+    .sidebar{position:fixed;inset:0 auto 0 0;width:260px;background:var(--card-bg);border-right:1px solid var(--border);box-shadow:20px 0 40px rgba(0,0,0,.35);padding:60px 20px 20px;display:flex;flex-direction:column;z-index:30;transition:width .3s ease,transform .3s ease,box-shadow .3s ease;overflow:hidden}
+    .sidebar.collapsed{width:72px;box-shadow:12px 0 30px rgba(0,0,0,.3)}
+    .sidebar.pinned{box-shadow:24px 0 44px rgba(0,0,0,.4)}
+    .sidebar .sidebar-content{position:relative;height:100%;overflow-y:auto;padding-right:6px}
+    .sidebar .label{transition:opacity .2s ease}
+    .sidebar.collapsed .label{opacity:0;pointer-events:none}
     .btn{border:0;border-radius:14px;padding:10px 16px;cursor:pointer;font-weight:600;transition:background-color .2s ease,border-color .2s ease,box-shadow .2s ease,transform .2s ease,color .2s ease;color:var(--ink)}
     .btn.ghost{background:var(--ghost);border:1px solid var(--ghost-border);box-shadow:inset 0 1px 0 rgba(255,255,255,.05)}
     .btn.primary{background:var(--btn);color:var(--btn-ink);box-shadow:0 12px 24px rgba(242,138,45,.35)}
@@ -221,20 +232,11 @@
     .chat-msg.ai .bubble{background:var(--ai-bubble-bg);border:1px solid var(--ai-bubble-border);color:var(--ink);box-shadow:0 10px 24px rgba(0,0,0,.4)}
 
     /* ===== Tokens de tema ===== */
-    .toolbar{background:var(--toolbar-bg);position:sticky;top:0;z-index:20;display:flex;align-items:center;padding:8px 12px}
-    .menu-toggle{background:transparent;border:none;font-size:24px;color:var(--ink);cursor:pointer;display:flex;align-items:center;justify-content:center;width:40px;height:40px;border-radius:8px;transition:background .2s ease}
-    .menu-toggle:hover,.menu-toggle:focus-visible{background:rgba(255,255,255,.08)}
-    .menu-toggle.close{position:absolute;top:12px;right:12px;font-size:22px}
-    .sidebar{position:fixed;inset:0 auto 0 0;width:280px;max-width:80vw;background:var(--card-bg);box-shadow:20px 0 40px rgba(0,0,0,.35);transform:translateX(-110%);transition:transform .3s ease;z-index:40;padding:60px 20px 20px;display:flex;flex-direction:column}
-    .sidebar.open,.sidebar[aria-hidden="false"]{transform:translateX(0)}
-    .sidebar-content{position:relative;height:100%;overflow-y:auto}
     .sidebar-list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:16px}
     .sidebar-list li{display:flex;flex-direction:column;gap:8px;color:var(--ink)}
     .sidebar-list li button.btn{align-self:flex-start}
     .auth-controls{gap:12px}
     .sidebar input,.sidebar select{border:1px solid var(--input-border);background:var(--input-bg);color:var(--ink)}
-    .sidebar-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.45);opacity:0;pointer-events:none;transition:opacity .3s ease;z-index:30}
-    .sidebar-backdrop.visible{opacity:1;pointer-events:auto}
     .btn.ghost:hover,.btn.ghost:focus-visible{background:var(--ghost-hover-bg);border-color:var(--ghost-hover-border)}
     .btn.ghost:active{background:var(--ghost-active-bg);border-color:var(--ghost-active-border)}
     .pill{border:1px solid var(--border)}
@@ -261,26 +263,33 @@
     .theme-btn-label{display:flex;align-items:center;gap:6px}
     .theme-btn-icon{font-size:12px;opacity:.8}
 
-    @media (max-width:680px){ .sidebar{width:240px} }
+    @media(max-width:960px){ body{padding-left:0} body.sidebar-expanded{padding-left:0} }
+    @media(max-width:768px){
+      .sidebar{transform:translateX(-110%);width:260px;box-shadow:0 0 0 rgba(0,0,0,0)}
+      .sidebar.pinned{transform:translateX(0);box-shadow:20px 0 40px rgba(0,0,0,.35)}
+      .sidebar.collapsed{width:260px}
+    }
   </style>
 </head>
 <body>
-  <!-- toolbar -->
-  <div class="toolbar">
-    <button class="menu-toggle" id="btnMenuToggle" aria-expanded="false" aria-controls="sidebar" aria-label="Abrir menú">☰</button>
-  </div>
+  <header class="app-header">
+    <button type="button" class="sidebar-toggle" id="btnToggleSidebar" aria-expanded="false" aria-controls="sidebar" aria-label="Alternar navegación">
+      <span aria-hidden="true"></span>
+      <span aria-hidden="true"></span>
+      <span aria-hidden="true"></span>
+    </button>
+  </header>
 
-  <aside class="sidebar" id="sidebar" aria-hidden="true">
+  <aside class="sidebar collapsed" id="sidebar" data-pinned="false" aria-hidden="false">
     <div class="sidebar-content">
-      <button class="menu-toggle close" id="btnMenuClose" aria-label="Cerrar menú">×</button>
       <nav aria-label="Controles principales">
         <ul class="sidebar-list">
           <li>
-            <label for="q">Buscar</label>
+            <label class="label" for="q">Buscar</label>
             <input id="q" placeholder="Buscar por nombre, email o servicio…"/>
           </li>
           <li>
-            <label for="filterEstado">Estado</label>
+            <label class="label" for="filterEstado">Estado</label>
             <select id="filterEstado">
               <option value="">Todos</option>
               <option value="vigente">Vigentes</option>
@@ -290,8 +299,8 @@
           </li>
           <li>
             <div class="menu-wrap theme-switcher">
-              <button type="button" class="btn ghost theme-btn" id="btnTheme" data-menu-toggle aria-haspopup="menu" aria-expanded="false">
-                <span class="theme-btn-label">Tema: <span id="themeLabel">Oscuro</span></span>
+              <button type="button" class="btn ghost theme-btn label" id="btnTheme" data-menu-toggle aria-haspopup="menu" aria-expanded="false">
+                <span class="theme-btn-label label">Tema: <span id="themeLabel">Oscuro</span></span>
                 <span class="theme-btn-icon" aria-hidden="true">▾</span>
               </button>
               <div class="menu" id="themeMenu" role="menu">
@@ -301,18 +310,17 @@
             </div>
           </li>
           <li class="auth-controls">
-            <button class="btn ghost" id="btnAuthOpen">Acceder</button>
-            <button class="btn ghost" id="btnLogout" style="display:none">Cerrar sesión</button>
-            <span id="userInfo" class="pill" style="display:none"></span>
+            <button class="btn ghost label" id="btnAuthOpen">Acceder</button>
+            <button class="btn ghost label" id="btnLogout" style="display:none">Cerrar sesión</button>
+            <span id="userInfo" class="pill label" style="display:none"></span>
           </li>
           <li>
-            <button class="btn ghost" id="btnChatOpen" title="Abrir chat con Gemini">Chat Gemini</button>
+            <button class="btn ghost label" id="btnChatOpen" title="Abrir chat con Gemini">Chat Gemini</button>
           </li>
         </ul>
       </nav>
     </div>
   </aside>
-  <div class="sidebar-backdrop" id="sidebarBackdrop" hidden></div>
 
   <div class="wrap">
     <span class="pill">importante</span>
@@ -472,9 +480,8 @@ servicio:$('#servicio'),inicio:$('#inicio'),vence:$('#vence'),notas:$('#notas'),
 categoria:$('#categoria'), pin:$('#pin')};
 const q=$('#q'), filterEstado=$('#filterEstado'), msg=$('#msg');
 const sidebar=document.getElementById('sidebar');
-const sidebarToggle=document.getElementById('btnMenuToggle');
-const sidebarClose=document.getElementById('btnMenuClose');
-const sidebarBackdrop=document.getElementById('sidebarBackdrop');
+const sidebarToggle=document.getElementById('btnToggleSidebar');
+const sidebarMobileQuery=window.matchMedia? window.matchMedia('(max-width: 768px)') : { matches:false };
 const themeButton=document.getElementById('btnTheme');
 const themeLabel=document.getElementById('themeLabel');
 const themeMenu=document.getElementById('themeMenu');
@@ -482,28 +489,54 @@ const themeOptions=Array.from(themeMenu?.querySelectorAll('[data-theme-option]')
 const THEME_STORAGE_KEY='ui_theme_mode_v1';
 let editId=null;
 
-function openSidebar(){
+function isMobileSidebar(){ return sidebarMobileQuery.matches; }
+
+function syncSidebarResponsiveState(){
   if(!sidebar) return;
-  sidebar.classList.add('open');
-  sidebar.setAttribute('aria-hidden','false');
-  sidebarToggle?.setAttribute('aria-expanded','true');
-  sidebarBackdrop?.classList.add('visible');
-  sidebarBackdrop?.removeAttribute('hidden');
+  const pinned = sidebar.dataset.pinned === 'true';
+  sidebar.classList.toggle('pinned', pinned);
+  if(isMobileSidebar()){
+    sidebar.classList.remove('collapsed');
+    sidebar.setAttribute('aria-hidden', pinned ? 'false' : 'true');
+    sidebarToggle?.classList.toggle('is-open', pinned);
+    sidebarToggle?.setAttribute('aria-expanded', pinned ? 'true' : 'false');
+    document.body.classList.remove('sidebar-expanded');
+  }else{
+    sidebar.classList.toggle('collapsed', !pinned);
+    sidebar.setAttribute('aria-hidden','false');
+    sidebarToggle?.classList.toggle('is-open', pinned);
+    sidebarToggle?.setAttribute('aria-expanded', pinned ? 'true' : 'false');
+    document.body.classList.toggle('sidebar-expanded', pinned);
+  }
 }
 
-function closeSidebar(){
+function setSidebarPinned(pinned){
   if(!sidebar) return;
-  sidebar.classList.remove('open');
-  sidebar.setAttribute('aria-hidden','true');
-  sidebarToggle?.setAttribute('aria-expanded','false');
-  sidebarBackdrop?.classList.remove('visible');
-  sidebarBackdrop?.setAttribute('hidden','');
+  sidebar.dataset.pinned = String(pinned);
+  syncSidebarResponsiveState();
 }
 
-function toggleSidebar(){
-  if(sidebar?.classList.contains('open')) closeSidebar();
-  else openSidebar();
+function expandSidebarIfNeeded(){
+  if(!sidebar || isMobileSidebar()) return;
+  if(sidebar.dataset.pinned === 'true') return;
+  sidebar.classList.remove('collapsed');
 }
+
+function collapseSidebarIfNeeded(){
+  if(!sidebar || isMobileSidebar()) return;
+  if(sidebar.dataset.pinned === 'true') return;
+  sidebar.classList.add('collapsed');
+}
+
+if(sidebar){
+  syncSidebarResponsiveState();
+  if(!isMobileSidebar()) collapseSidebarIfNeeded();
+}
+
+const handleSidebarMediaChange = ()=>{
+  syncSidebarResponsiveState();
+  if(!isMobileSidebar()) collapseSidebarIfNeeded();
+};
 
 function toast(t){ msg.textContent=t; setTimeout(()=>msg.textContent='',2200); }
 function esc(s){return (s||'').replace(/[&<>"']/g,m=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#039;' }[m]))}
@@ -645,17 +678,32 @@ toggleAuthPass?.addEventListener('click', ()=>{
   toggleAuthPass.textContent = isPass? '🙈':'👁';
 });
 
-sidebarToggle?.addEventListener('click', (e)=>{ e.stopPropagation(); toggleSidebar(); });
-sidebarClose?.addEventListener('click', (e)=>{ e.stopPropagation(); closeSidebar(); });
-sidebarBackdrop?.addEventListener('click', ()=> closeSidebar());
-document.addEventListener('click', (e)=>{
+sidebarToggle?.addEventListener('click', ()=>{
   if(!sidebar) return;
-  if(!sidebar.classList.contains('open')) return;
-  if(sidebar.contains(e.target)) return;
-  if(e.target===sidebarToggle) return;
-  closeSidebar();
+  const nextPinned = sidebar.dataset.pinned !== 'true';
+  setSidebarPinned(nextPinned);
 });
-document.addEventListener('keydown', (e)=>{ if(e.key==='Escape') closeSidebar(); });
+
+sidebar?.addEventListener('mouseenter', expandSidebarIfNeeded);
+sidebar?.addEventListener('mouseleave', collapseSidebarIfNeeded);
+sidebar?.addEventListener('focusin', expandSidebarIfNeeded);
+sidebar?.addEventListener('focusout', (event)=>{
+  if(!sidebar) return;
+  if(sidebar.contains(event.relatedTarget)) return;
+  collapseSidebarIfNeeded();
+});
+if(sidebarMobileQuery.addEventListener){
+  sidebarMobileQuery.addEventListener('change', handleSidebarMediaChange);
+}else if(sidebarMobileQuery.addListener){
+  sidebarMobileQuery.addListener(handleSidebarMediaChange);
+}
+document.addEventListener('keydown', (e)=>{
+  if(e.key!=='Escape') return;
+  if(!sidebar) return;
+  if(sidebar.dataset.pinned === 'true'){
+    setSidebarPinned(false);
+  }
+});
 
 // ----- Lógica unificada: registrar o iniciar sesión -----
 async function autoSignInOrUp(email, password) {


### PR DESCRIPTION
## Summary
- replace the old toolbar and sidebar markup with a sticky header toggle and updated sidebar structure that supports collapsed and pinned layouts
- add CSS transitions for the sidebar widths, label opacity, and hamburger-to-close animation on the toggle button
- update the client script to handle hover expansion, pin toggling, and mobile slide-in behavior for the sidebar

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68d0252115888326a3b8b7d11cfa7342