### PR TITLE
Replace top toolbar with floating sidebar launcher

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
     }
     *{box-sizing:border-box;font-family:Inter,ui-sans-serif,system-ui,Segoe UI,Roboto,Arial}
     html,body{margin:0;min-height:100%;background:var(--bg);color:var(--ink)}
-    body{position:relative;min-height:100vh;overflow-x:hidden;padding-left:72px;transition:padding-left .3s ease}
+    body{position:relative;min-height:100vh;overflow-x:hidden;padding-left:0;transition:padding-left .3s ease}
     body::before{content:"";position:fixed;inset:-40%;background:radial-gradient(circle at 20% 20%,rgba(242,138,45,.08),rgba(0,0,0,0) 45%),radial-gradient(circle at 80% 10%,rgba(125,211,252,.06),rgba(0,0,0,0) 52%),radial-gradient(circle at 30% 80%,rgba(22,242,166,.04),rgba(0,0,0,0) 55%);pointer-events:none;z-index:-1;filter:blur(0px)}
     body.theme-light{
       color-scheme:light;
@@ -96,24 +96,19 @@
     a{color:inherit}
 
     body.sidebar-expanded{padding-left:260px}
-    /* ===== Header y sidebar ===== */
-    .app-header{position:sticky;top:0;z-index:40;display:flex;align-items:center;gap:12px;padding:12px 16px;background:var(--toolbar-bg);border-bottom:1px solid var(--border);backdrop-filter:saturate(160%) blur(16px);box-shadow:var(--shadow)}
-    .sidebar-toggle{position:relative;width:44px;height:44px;border-radius:12px;border:1px solid transparent;background:transparent;color:var(--ink);cursor:pointer;display:flex;align-items:center;justify-content:center;transition:background-color .2s ease,border-color .2s ease}
-    .sidebar-toggle span{position:absolute;width:20px;height:2px;background:currentColor;border-radius:2px;transition:transform .25s ease,opacity .25s ease,top .25s ease}
-    .sidebar-toggle span:nth-child(1){top:16px}
-    .sidebar-toggle span:nth-child(2){top:21px}
-    .sidebar-toggle span:nth-child(3){top:26px}
-    .sidebar-toggle:hover,.sidebar-toggle:focus-visible{background:rgba(255,255,255,.08);border-color:rgba(255,255,255,.18)}
-    .sidebar-toggle:focus-visible{outline:2px solid rgba(125,211,252,.35);outline-offset:2px}
-    .sidebar-toggle.is-open span:nth-child(1){top:21px;transform:rotate(45deg)}
-    .sidebar-toggle.is-open span:nth-child(2){opacity:0}
-    .sidebar-toggle.is-open span:nth-child(3){top:21px;transform:rotate(-45deg)}
-    .sidebar{position:fixed;inset:0 auto 0 0;width:260px;background:var(--card-bg);border-right:1px solid var(--border);box-shadow:20px 0 40px rgba(0,0,0,.35);padding:60px 20px 20px;display:flex;flex-direction:column;z-index:30;transition:width .3s ease,transform .3s ease,box-shadow .3s ease;overflow:hidden}
-    .sidebar.collapsed{width:72px;box-shadow:12px 0 30px rgba(0,0,0,.3)}
-    .sidebar.pinned{box-shadow:24px 0 44px rgba(0,0,0,.4)}
+    /* ===== Sidebar y lanzador flotante ===== */
+    .sidebar-launcher{position:fixed;top:20px;left:20px;width:54px;height:54px;border-radius:999px;border:1px solid rgba(255,255,255,.18);background:var(--card-bg);color:var(--ink);display:flex;align-items:center;justify-content:center;font-size:24px;cursor:pointer;z-index:60;box-shadow:0 18px 36px rgba(0,0,0,.45);backdrop-filter:blur(18px);transition:left .3s ease,transform .2s ease,box-shadow .2s ease,background-color .2s ease,border-color .2s ease}
+    .sidebar-launcher:hover,.sidebar-launcher:focus-visible{transform:translateY(-1px);box-shadow:0 24px 40px rgba(0,0,0,.5);background:rgba(255,255,255,.08);border-color:rgba(255,255,255,.26)}
+    .sidebar-launcher:active{transform:translateY(0);box-shadow:0 14px 28px rgba(0,0,0,.55)}
+    .sidebar-launcher:focus-visible{outline:2px solid rgba(125,211,252,.35);outline-offset:3px}
+    .sidebar-launcher.is-open{background:var(--btn);color:var(--btn-ink);border-color:rgba(255,255,255,.2);box-shadow:0 24px 44px rgba(0,0,0,.5)}
+    .sidebar-launcher.is-open:hover,.sidebar-launcher.is-open:focus-visible{background:#ffa24d}
+    body.sidebar-expanded .sidebar-launcher{left:220px}
+    .sidebar{position:fixed;inset:0 auto 0 0;width:260px;background:var(--card-bg);border-right:1px solid var(--border);box-shadow:20px 0 40px rgba(0,0,0,.35);padding:60px 20px 20px;display:flex;flex-direction:column;z-index:30;transition:transform .3s ease,box-shadow .3s ease;overflow:hidden;transform:translateX(-100%)}
+    .sidebar.pinned,.sidebar.peek{transform:translateX(0)}
+    .sidebar.pinned,.sidebar.peek{box-shadow:24px 0 44px rgba(0,0,0,.4)}
     .sidebar .sidebar-content{position:relative;height:100%;overflow-y:auto;padding-right:6px}
     .sidebar .label{transition:opacity .2s ease}
-    .sidebar.collapsed .label{opacity:0;pointer-events:none}
     .btn{border:0;border-radius:14px;padding:10px 16px;cursor:pointer;font-weight:600;transition:background-color .2s ease,border-color .2s ease,box-shadow .2s ease,transform .2s ease,color .2s ease;color:var(--ink)}
     .btn.ghost{background:var(--ghost);border:1px solid var(--ghost-border);box-shadow:inset 0 1px 0 rgba(255,255,255,.05)}
     .btn.primary{background:var(--btn);color:var(--btn-ink);box-shadow:0 12px 24px rgba(242,138,45,.35)}
@@ -263,24 +258,18 @@
     .theme-btn-label{display:flex;align-items:center;gap:6px}
     .theme-btn-icon{font-size:12px;opacity:.8}
 
-    @media(max-width:960px){ body{padding-left:0} body.sidebar-expanded{padding-left:0} }
+    @media(max-width:960px){ body.sidebar-expanded{padding-left:0} }
     @media(max-width:768px){
-      .sidebar{transform:translateX(-110%);width:260px;box-shadow:0 0 0 rgba(0,0,0,0)}
-      .sidebar.pinned{transform:translateX(0);box-shadow:20px 0 40px rgba(0,0,0,.35)}
-      .sidebar.collapsed{width:260px}
+      .sidebar{box-shadow:0 0 0 rgba(0,0,0,0)}
+      .sidebar.pinned,.sidebar.peek{box-shadow:20px 0 40px rgba(0,0,0,.35)}
+      body.sidebar-expanded .sidebar-launcher{left:20px}
     }
   </style>
 </head>
 <body>
-  <header class="app-header">
-    <button type="button" class="sidebar-toggle" id="btnToggleSidebar" aria-expanded="false" aria-controls="sidebar" aria-label="Alternar navegación">
-      <span aria-hidden="true"></span>
-      <span aria-hidden="true"></span>
-      <span aria-hidden="true"></span>
-    </button>
-  </header>
+  <button type="button" id="sidebarLauncher" class="sidebar-launcher" aria-controls="sidebar" aria-label="Abrir navegación" aria-expanded="false">☰</button>
 
-  <aside class="sidebar collapsed" id="sidebar" data-pinned="false" aria-hidden="false">
+  <aside class="sidebar" id="sidebar" data-pinned="false" aria-hidden="true">
     <div class="sidebar-content">
       <nav aria-label="Controles principales">
         <ul class="sidebar-list">
@@ -480,7 +469,7 @@ servicio:$('#servicio'),inicio:$('#inicio'),vence:$('#vence'),notas:$('#notas'),
 categoria:$('#categoria'), pin:$('#pin')};
 const q=$('#q'), filterEstado=$('#filterEstado'), msg=$('#msg');
 const sidebar=document.getElementById('sidebar');
-const sidebarToggle=document.getElementById('btnToggleSidebar');
+const sidebarLauncher=document.getElementById('sidebarLauncher');
 const sidebarMobileQuery=window.matchMedia? window.matchMedia('(max-width: 768px)') : { matches:false };
 const themeButton=document.getElementById('btnTheme');
 const themeLabel=document.getElementById('themeLabel');
@@ -495,17 +484,17 @@ function syncSidebarResponsiveState(){
   if(!sidebar) return;
   const pinned = sidebar.dataset.pinned === 'true';
   sidebar.classList.toggle('pinned', pinned);
+  const isVisible = pinned || (!isMobileSidebar() && sidebar.classList.contains('peek'));
+  sidebar.setAttribute('aria-hidden', isVisible ? 'false' : 'true');
+  if(sidebarLauncher){
+    sidebarLauncher.setAttribute('aria-expanded', pinned ? 'true' : 'false');
+    sidebarLauncher.textContent = pinned ? '✕' : '☰';
+    sidebarLauncher.setAttribute('aria-label', pinned ? 'Cerrar navegación' : 'Abrir navegación');
+    sidebarLauncher.classList.toggle('is-open', pinned);
+  }
   if(isMobileSidebar()){
-    sidebar.classList.remove('collapsed');
-    sidebar.setAttribute('aria-hidden', pinned ? 'false' : 'true');
-    sidebarToggle?.classList.toggle('is-open', pinned);
-    sidebarToggle?.setAttribute('aria-expanded', pinned ? 'true' : 'false');
     document.body.classList.remove('sidebar-expanded');
   }else{
-    sidebar.classList.toggle('collapsed', !pinned);
-    sidebar.setAttribute('aria-hidden','false');
-    sidebarToggle?.classList.toggle('is-open', pinned);
-    sidebarToggle?.setAttribute('aria-expanded', pinned ? 'true' : 'false');
     document.body.classList.toggle('sidebar-expanded', pinned);
   }
 }
@@ -513,29 +502,34 @@ function syncSidebarResponsiveState(){
 function setSidebarPinned(pinned){
   if(!sidebar) return;
   sidebar.dataset.pinned = String(pinned);
+  if(!pinned){
+    sidebar.classList.remove('peek');
+  }
   syncSidebarResponsiveState();
 }
 
 function expandSidebarIfNeeded(){
   if(!sidebar || isMobileSidebar()) return;
   if(sidebar.dataset.pinned === 'true') return;
-  sidebar.classList.remove('collapsed');
+  sidebar.classList.add('peek');
+  sidebar.setAttribute('aria-hidden','false');
 }
 
 function collapseSidebarIfNeeded(){
-  if(!sidebar || isMobileSidebar()) return;
+  if(!sidebar) return;
   if(sidebar.dataset.pinned === 'true') return;
-  sidebar.classList.add('collapsed');
+  sidebar.classList.remove('peek');
+  sidebar.setAttribute('aria-hidden','true');
 }
 
 if(sidebar){
   syncSidebarResponsiveState();
-  if(!isMobileSidebar()) collapseSidebarIfNeeded();
+  collapseSidebarIfNeeded();
 }
 
 const handleSidebarMediaChange = ()=>{
   syncSidebarResponsiveState();
-  if(!isMobileSidebar()) collapseSidebarIfNeeded();
+  collapseSidebarIfNeeded();
 };
 
 function toast(t){ msg.textContent=t; setTimeout(()=>msg.textContent='',2200); }
@@ -678,7 +672,7 @@ toggleAuthPass?.addEventListener('click', ()=>{
   toggleAuthPass.textContent = isPass? '🙈':'👁';
 });
 
-sidebarToggle?.addEventListener('click', ()=>{
+sidebarLauncher?.addEventListener('click', ()=>{
   if(!sidebar) return;
   const nextPinned = sidebar.dataset.pinned !== 'true';
   setSidebarPinned(nextPinned);


### PR DESCRIPTION
## Summary
- remove the sticky toolbar block and its styling
- add a floating sidebar launcher button with updated sidebar hiding animation
- update the sidebar script to drive the new launcher and aria state handling

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d02ab7d8088326b7cd8341cee99325