### PR TITLE
Actualiza cabecera con icono combinado

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,7 +129,12 @@
     /* ===== Layout ===== */
     .wrap{width:min(1200px,92vw);margin:0 auto;padding:36px 18px 80px;position:relative;z-index:0}
     .pill{display:block;width:max-content;margin:0 auto 14px;padding:6px 14px;border-radius:999px;background:var(--pill-bg);color:var(--pill-ink);border:1px solid rgba(255,255,255,.24);font-size:12px;letter-spacing:.08em;text-transform:uppercase}
-    h1{margin:6px 0 20px;text-align:center;font-weight:800;letter-spacing:-0.02em;color:var(--ink);font-size:clamp(72px,16vw,144px);line-height:1.02;text-shadow:0 12px 32px rgba(0,0,0,.55)}
+    .hero-brand{display:flex;align-items:center;justify-content:center;flex-wrap:wrap;gap:clamp(12px,3vw,28px);margin:6px 0 24px;text-align:center}
+    .hero-brand img{width:clamp(64px,16vw,132px);height:auto;flex-shrink:0;filter:drop-shadow(0 18px 36px rgba(0,0,0,.55));border-radius:24px}
+    .hero-brand span{display:block;font-weight:800;letter-spacing:-0.02em;color:var(--ink);font-size:clamp(54px,16vw,144px);line-height:.95;text-shadow:0 12px 32px rgba(0,0,0,.55);text-transform:uppercase}
+    @media(max-width:520px){
+      .hero-brand span{font-size:clamp(42px,20vw,96px)}
+    }
 
     /* ===== Servicio centrado ===== */
     .center{display:flex;justify-content:center;align-items:center;gap:10px;margin:8px 0 20px}
@@ -313,7 +318,10 @@
 
   <div class="wrap">
     <span class="pill">importante</span>
-    <h1>SUPERZYLO</h1>
+    <div class="hero-brand" role="heading" aria-level="1">
+      <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 120 120'%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0%25' y1='0%25' x2='100%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%237dd3fc'/%3E%3Cstop offset='55%25' stop-color='%2316f2a6'/%3E%3Cstop offset='100%25' stop-color='%23f28a2d'/%3E%3C/linearGradient%3E%3C/defs%3E%3Cpath fill='url(%23g)' d='M98.7 22.3C70.8 12.7 38.5 18.4 22.9 41.3 7.3 64.1 6.9 96 33 96c23.2 0 46.4-23.4 57.4-48.6 5.5-12.7 7.7-23.5 8.3-25.1Z'/%3E%3Cpath fill='none' stroke='rgba(255,255,255,0.6)' stroke-width='6' stroke-linecap='round' d='M36 74c16-8 36-28 47-50'/%3E%3C/svg%3E" alt="Hoja Super Zylo" loading="lazy"/>
+      <span>Super Zylo</span>
+    </div>
 
     <div class="center">
       <div class="label">Servicio</div>


### PR DESCRIPTION
## Summary
- reemplaza el título principal por un bloque de marca con icono e introduce datos accesibles
- añade los estilos responsivos para alinear el icono y el texto en la cabecera

## Testing
- No tests were run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d030cadcd88326bb52558c7683d36b