### PR TITLE
Rediseña etiqueta de WhatsApp

### DIFF
--- a/index.html
+++ b/index.html
@@ -1283,23 +1283,22 @@ function buildEtiqueta(c){
   const password = c.password || c.contrasena || c.pass || c.clave || '—';
   const notas = (c.notas || '').trim() || 'Sin notas adicionales.';
 
-  const etiqueta = `🍃 *${svc || 'SERVICIO'}*
-━━━━━━━━━━━━━━━━━━
-🗓️ *Inicio:* ${fi}
+  const etiqueta = `🌈✨ *${svc || 'SERVICIO'}* ✨🌈
+━━━━━━━━━━━━━━━━━━━━
 📅 *Vence:* ${fv}
+🗓️ *Inicio:* ${fi}
 
-👤 *Perfil*
+👥 *Perfil & Acceso*
    • Nombre: ${perfil}
    • Correo: ${correo}
-
-🔐 *Acceso*
-   • PIN: ${pin}
    • Contraseña: ${password}
+   • PIN: ${pin}
+━━━━━━━━━━━━━━━━━━━━
 
-📝 *Notas*
+🌸 *Notas mágicas*
 ${notas}
 
-💻📲  🌟 Gracias por tu compra`;
+💬✨ Lista para WhatsApp`;
 
   // Probado manualmente: el texto se copia correctamente (copyToClipboard) y conserva el formato en WhatsApp.
   return etiqueta;


### PR DESCRIPTION
## Summary
- actualiza el formato generado por buildEtiqueta para mostrar encabezado decorativo, fechas y sección combinada de perfil y acceso
- añade separadores y notas estilizadas listas para copiar en WhatsApp

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0373d9bf88326a13e9f8e92d7bc83