### PR TITLE
Cerrar panel lateral al tocar fuera en móviles

### DIFF
--- a/index.html
+++ b/index.html
@@ -753,6 +753,19 @@ document.addEventListener('keydown', (e)=>{
   }
 });
 
+document.addEventListener('pointerdown', (event)=>{
+  if(!sidebar) return;
+  if(sidebar.dataset.pinned !== 'true') return;
+  const target = event.target;
+  if(target instanceof Node){
+    if(sidebar.contains(target)) return;
+    if(sidebarLauncher?.contains?.(target)) return;
+  }
+  if(isMobileSidebar()){
+    setSidebarPinned(false);
+  }
+});
+
 // ----- Lógica unificada: registrar o iniciar sesión -----
 async function autoSignInOrUp(email, password) {
   // 1) Intenta iniciar sesión primero


### PR DESCRIPTION
## Resumen
- cerrar automáticamente el panel lateral cuando está abierto en vista móvil y el usuario toca fuera de él
- ignorar toques dentro del panel o sobre el botón lanzador para evitar cierres accidentales

## Pruebas
- no se realizaron pruebas automatizadas

------
https://chatgpt.com/codex/tasks/task_e_68d0629d4f48832699757b1a78b15a6a