### PR TITLE
Use linked account password when building etiquetas

### DIFF
--- a/index.html
+++ b/index.html
@@ -1856,12 +1856,14 @@ async function applyUpdateCommand(cmd){
 
 function formatDM(iso){ if(!iso) return ''; var d=new Date(iso+'T00:00:00'); return String(d.getDate()).padStart(2,'0')+'/'+String(d.getMonth()+1).padStart(2,'0'); }
 function buildEtiqueta(c){
+  const linkedAccount = findLinkedAccount(c.servicio, c.email);
   const svc = (c.servicio || '').toString().toUpperCase();
   const fv = formatDM(c.vence) || '--/--';
   const correo = c.email || '—';
   const perfil = c.nombre || '—';
   const pin = c.pin || '—';
-  const password = c.password || c.contrasena || c.pass || c.clave || '—';
+  const password = linkedAccount?.password
+    || c.password || c.contrasena || c.pass || c.clave || '—';
   const etiqueta = `✨ *${svc || 'SERVICIO'}* 
 ━━━━━━━━━━━━━━━
 📅 *Vence:* ${fv}


### PR DESCRIPTION
## Summary
- call `findLinkedAccount` when constructing etiquetas so linked passwords are used when available

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d07efdcca08326a3155fc6477040cd