### PR TITLE
Improve linked email modal suggestion dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -538,13 +538,14 @@
           <label for="linkedService">Servicio</label>
           <select id="linkedService"></select>
         </div>
-        <div class="row">
+        <div class="row suggestion-source">
           <label for="linkedEmail">Correo</label>
           <div class="linked-email-wrap">
-            <input id="linkedEmail" type="email" placeholder="correo@ejemplo.com" autocomplete="off" list="linkedEmailOptions">
+            <input id="linkedEmail" type="email" placeholder="correo@ejemplo.com" autocomplete="off">
+            <button class="btn ghost icon-only" id="btnLinkedEmailDropdown" type="button" aria-label="Mostrar correos guardados">▾</button>
             <button class="btn ghost danger icon-only" id="btnLinkedDelete" type="button" aria-label="Eliminar correo enlazado">−</button>
           </div>
-          <datalist id="linkedEmailOptions"></datalist>
+          <div id="linkedEmailSuggestionDropdown" class="suggestion-dropdown" role="listbox" aria-hidden="true"></div>
         </div>
         <div class="row">
           <label for="linkedPassword">Contraseña</label>
@@ -1089,10 +1090,124 @@ const btnLinkedSave = document.getElementById('btnLinkedSave');
 const btnLinkedDelete = document.getElementById('btnLinkedDelete');
 const linkedServiceEl = document.getElementById('linkedService');
 const linkedEmailEl = document.getElementById('linkedEmail');
-const linkedEmailOptions = document.getElementById('linkedEmailOptions');
+const linkedEmailSuggestionDropdown = document.getElementById('linkedEmailSuggestionDropdown');
+const btnLinkedEmailDropdown = document.getElementById('btnLinkedEmailDropdown');
 const linkedPasswordEl = document.getElementById('linkedPassword');
 const toggleLinkedPassword = document.getElementById('toggleLinkedPassword');
 const linkedErrorEl = document.getElementById('linkedError');
+
+let filteredLinkedEmailSuggestions = [];
+let activeLinkedEmailSuggestionIndex = -1;
+let hideLinkedEmailSuggestionTimeout = null;
+
+function hideLinkedEmailSuggestions(){
+  if(!linkedEmailSuggestionDropdown) return;
+  linkedEmailSuggestionDropdown.classList.remove('open');
+  linkedEmailSuggestionDropdown.setAttribute('aria-hidden','true');
+  linkedEmailSuggestionDropdown.innerHTML='';
+  filteredLinkedEmailSuggestions=[];
+  activeLinkedEmailSuggestionIndex=-1;
+  if(hideLinkedEmailSuggestionTimeout){
+    clearTimeout(hideLinkedEmailSuggestionTimeout);
+    hideLinkedEmailSuggestionTimeout=null;
+  }
+}
+
+function isLinkedEmailSuggestionDropdownOpen(){
+  return !!linkedEmailSuggestionDropdown && linkedEmailSuggestionDropdown.classList.contains('open');
+}
+
+function updateLinkedEmailSuggestions(filterText){
+  if(!linkedEmailSuggestionDropdown || !linkedEmailEl) return;
+  if(linkedEmailEl.disabled){ hideLinkedEmailSuggestions(); return; }
+
+  const servicio = linkedServiceEl?.value || '';
+  if(!servicio){
+    filteredLinkedEmailSuggestions=[];
+    linkedEmailSuggestionDropdown.innerHTML=`<div class="suggestion-empty">${esc('Selecciona un servicio')}</div>`;
+    linkedEmailSuggestionDropdown.classList.add('open');
+    linkedEmailSuggestionDropdown.setAttribute('aria-hidden','false');
+    activeLinkedEmailSuggestionIndex=-1;
+    return;
+  }
+
+  const suggestions = getStoredLinkedAccountsForService(servicio);
+  const term = typeof filterText==='string'
+    ? filterText.trim().toLowerCase()
+    : (linkedEmailEl.value||'').trim().toLowerCase();
+
+  filteredLinkedEmailSuggestions = suggestions.filter(item=>{
+    return !term || item.email.toLowerCase().includes(term);
+  });
+
+  if(!filteredLinkedEmailSuggestions.length){
+    const emptyLabel = term ? 'Sin coincidencias' : 'Sin correos enlazados';
+    linkedEmailSuggestionDropdown.innerHTML=`<div class="suggestion-empty">${esc(emptyLabel)}</div>`;
+    linkedEmailSuggestionDropdown.classList.add('open');
+    linkedEmailSuggestionDropdown.setAttribute('aria-hidden','false');
+    activeLinkedEmailSuggestionIndex=-1;
+    return;
+  }
+
+  const html = filteredLinkedEmailSuggestions.map((item, idx)=>{
+    const hint = item.password ? '<span class="suggestion-hint">Contraseña guardada</span>' : '';
+    return `<button type="button" class="suggestion-item" data-index="${idx}" role="option">`
+      + `<span class="suggestion-email">${esc(item.email)}</span>`
+      + hint
+      + `</button>`;
+  }).join('');
+
+  linkedEmailSuggestionDropdown.innerHTML = html;
+  linkedEmailSuggestionDropdown.classList.add('open');
+  linkedEmailSuggestionDropdown.setAttribute('aria-hidden','false');
+  activeLinkedEmailSuggestionIndex=-1;
+
+  Array.from(linkedEmailSuggestionDropdown.querySelectorAll('.suggestion-item')).forEach(btn=>{
+    btn.addEventListener('mousedown',event=>event.preventDefault());
+    btn.addEventListener('click',()=>{
+      const idx = Number(btn.dataset.index);
+      selectLinkedEmailSuggestion(idx);
+    });
+  });
+}
+
+function showLinkedEmailSuggestions(filterText){
+  updateLinkedEmailSuggestions(filterText);
+}
+
+function highlightLinkedEmailSuggestion(idx){
+  if(!linkedEmailSuggestionDropdown) return;
+  const items = Array.from(linkedEmailSuggestionDropdown.querySelectorAll('.suggestion-item'));
+  items.forEach(item=>item.classList.remove('is-active'));
+  if(idx>=0 && items[idx]){
+    items[idx].classList.add('is-active');
+    items[idx].scrollIntoView({ block:'nearest' });
+  }
+}
+
+function moveLinkedEmailSuggestion(delta){
+  if(!linkedEmailSuggestionDropdown) return;
+  if(!filteredLinkedEmailSuggestions.length){
+    updateLinkedEmailSuggestions();
+    if(!filteredLinkedEmailSuggestions.length) return;
+  }
+  if(!isLinkedEmailSuggestionDropdownOpen()){
+    linkedEmailSuggestionDropdown.classList.add('open');
+    linkedEmailSuggestionDropdown.setAttribute('aria-hidden','false');
+  }
+  activeLinkedEmailSuggestionIndex = (activeLinkedEmailSuggestionIndex + delta + filteredLinkedEmailSuggestions.length) % filteredLinkedEmailSuggestions.length;
+  highlightLinkedEmailSuggestion(activeLinkedEmailSuggestionIndex);
+}
+
+function selectLinkedEmailSuggestion(idx){
+  const account = filteredLinkedEmailSuggestions[idx];
+  if(!account) return;
+  if(linkedEmailEl) linkedEmailEl.value = account.email;
+  if(linkedErrorEl) linkedErrorEl.textContent='';
+  syncLinkedEmailState({ resetPassword: true });
+  hideLinkedEmailSuggestions();
+  setTimeout(()=>linkedEmailEl?.focus(), 0);
+}
 
 function applyLinkedAccountToForm(servicio){
   const previousEmail = linkedEmailEl? linkedEmailEl.value.trim():'';
@@ -1103,18 +1218,10 @@ function applyLinkedAccountToForm(servicio){
   }
   if(toggleLinkedPassword) toggleLinkedPassword.textContent = '👁';
   if(btnLinkedDelete) btnLinkedDelete.disabled = true;
-  if(linkedEmailOptions) linkedEmailOptions.innerHTML = '';
+  hideLinkedEmailSuggestions();
   if(!servicio) return;
 
   const stored = getStoredLinkedAccountsForService(servicio);
-  if(linkedEmailOptions){
-    stored.forEach(item => {
-      const opt = document.createElement('option');
-      opt.value = item.email;
-      if(item.password) opt.label = 'Contraseña guardada';
-      linkedEmailOptions.appendChild(opt);
-    });
-  }
 
   let nextEmail = '';
   if(previousEmail && stored.some(item => linkedEmailKey(item.email) === linkedEmailKey(previousEmail))){
@@ -1174,7 +1281,7 @@ async function populateLinkedServices(){
     linkedServiceEl.appendChild(option);
     linkedServiceEl.disabled = true;
     if(linkedEmailEl){ linkedEmailEl.value=''; linkedEmailEl.disabled = true; }
-    if(linkedEmailOptions) linkedEmailOptions.innerHTML='';
+    hideLinkedEmailSuggestions();
     if(linkedPasswordEl){ linkedPasswordEl.value=''; linkedPasswordEl.disabled = true; linkedPasswordEl.type='password'; }
     if(btnLinkedSave) btnLinkedSave.disabled = true;
     if(toggleLinkedPassword) toggleLinkedPassword.textContent = '👁';
@@ -1236,6 +1343,7 @@ function closeLinkedModal(){
   if(linkedPasswordEl) linkedPasswordEl.type='password';
   if(toggleLinkedPassword) toggleLinkedPassword.textContent='👁';
   if(linkedErrorEl) linkedErrorEl.textContent='';
+  hideLinkedEmailSuggestions();
 }
 
 btnLinkedOpen?.addEventListener('click', openLinkedModal);
@@ -1247,16 +1355,109 @@ document.addEventListener('keydown', (e)=>{ if(e.key==='Escape') closeLinkedModa
 linkedServiceEl?.addEventListener('change', ()=>{
   applyLinkedAccountToForm(linkedServiceEl.value);
   if(linkedErrorEl) linkedErrorEl.textContent='';
+  hideLinkedEmailSuggestions();
 });
 
-linkedEmailEl?.addEventListener('input', ()=>{
-  if(linkedErrorEl) linkedErrorEl.textContent='';
-  syncLinkedEmailState({ resetPassword: true });
+if(linkedEmailEl){
+  linkedEmailEl.addEventListener('focus', ()=>{
+    if(linkedEmailEl.disabled) return;
+    if(hideLinkedEmailSuggestionTimeout){
+      clearTimeout(hideLinkedEmailSuggestionTimeout);
+      hideLinkedEmailSuggestionTimeout=null;
+    }
+    showLinkedEmailSuggestions();
+  });
+
+  linkedEmailEl.addEventListener('click', ()=>{
+    if(linkedEmailEl.disabled) return;
+    if(hideLinkedEmailSuggestionTimeout){
+      clearTimeout(hideLinkedEmailSuggestionTimeout);
+      hideLinkedEmailSuggestionTimeout=null;
+    }
+    showLinkedEmailSuggestions();
+  });
+
+  linkedEmailEl.addEventListener('input', ()=>{
+    if(linkedErrorEl) linkedErrorEl.textContent='';
+    syncLinkedEmailState({ resetPassword: true });
+    if(linkedEmailEl.disabled) return;
+    if(hideLinkedEmailSuggestionTimeout){
+      clearTimeout(hideLinkedEmailSuggestionTimeout);
+      hideLinkedEmailSuggestionTimeout=null;
+    }
+    showLinkedEmailSuggestions(linkedEmailEl.value);
+  });
+
+  linkedEmailEl.addEventListener('keydown',(e)=>{
+    if(e.key==='ArrowDown'){
+      e.preventDefault();
+      moveLinkedEmailSuggestion(1);
+    }else if(e.key==='ArrowUp'){
+      if(!isLinkedEmailSuggestionDropdownOpen()) return;
+      e.preventDefault();
+      moveLinkedEmailSuggestion(-1);
+    }else if(e.key==='Enter'){
+      if(isLinkedEmailSuggestionDropdownOpen() && activeLinkedEmailSuggestionIndex>=0){
+        e.preventDefault();
+        selectLinkedEmailSuggestion(activeLinkedEmailSuggestionIndex);
+      }
+    }else if(e.key==='Escape'){
+      if(isLinkedEmailSuggestionDropdownOpen()){
+        e.preventDefault();
+        e.stopPropagation();
+        hideLinkedEmailSuggestions();
+      }
+    }
+  });
+
+  linkedEmailEl.addEventListener('blur', ()=>{
+    hideLinkedEmailSuggestionTimeout=setTimeout(()=>hideLinkedEmailSuggestions(),120);
+  });
+
+  linkedEmailEl.addEventListener('change', ()=>{
+    if(linkedErrorEl) linkedErrorEl.textContent='';
+    syncLinkedEmailState({ resetPassword: true });
+  });
+}
+
+btnLinkedEmailDropdown?.addEventListener('click', ()=>{
+  if(hideLinkedEmailSuggestionTimeout){
+    clearTimeout(hideLinkedEmailSuggestionTimeout);
+    hideLinkedEmailSuggestionTimeout=null;
+  }
+  if(linkedEmailEl?.disabled) return;
+  if(isLinkedEmailSuggestionDropdownOpen()){
+    hideLinkedEmailSuggestions();
+  }else{
+    linkedEmailEl?.focus();
+    showLinkedEmailSuggestions();
+  }
 });
 
-linkedEmailEl?.addEventListener('change', ()=>{
-  if(linkedErrorEl) linkedErrorEl.textContent='';
-  syncLinkedEmailState({ resetPassword: true });
+btnLinkedEmailDropdown?.addEventListener('mousedown',(event)=>{
+  event.preventDefault();
+});
+
+linkedEmailSuggestionDropdown?.addEventListener('mouseenter',()=>{
+  if(hideLinkedEmailSuggestionTimeout){
+    clearTimeout(hideLinkedEmailSuggestionTimeout);
+    hideLinkedEmailSuggestionTimeout=null;
+  }
+});
+
+linkedEmailSuggestionDropdown?.addEventListener('mouseleave',()=>{
+  hideLinkedEmailSuggestionTimeout=setTimeout(()=>hideLinkedEmailSuggestions(),120);
+});
+
+document.addEventListener('pointerdown',(event)=>{
+  if(!linkedEmailEl || !linkedEmailSuggestionDropdown) return;
+  const target = event.target;
+  if(target===linkedEmailEl) return;
+  if(target instanceof Node){
+    if(btnLinkedEmailDropdown?.contains?.(target)) return;
+    if(linkedEmailSuggestionDropdown.contains(target)) return;
+  }
+  hideLinkedEmailSuggestions();
 });
 
 toggleLinkedPassword?.addEventListener('click', ()=>{


### PR DESCRIPTION
## Summary
- replace the linked email datalist with a styled dropdown trigger and container that matches the Super Zylo UI
- add dedicated helpers to populate, filter, and select linked email suggestions leveraging existing stored accounts
- hook the modal events into the new dropdown interactions while keeping delete/password sync logic intact

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d0934d9a088326b47773d248aade24