### PR TITLE
Add blurred dark theme background image

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,18 @@
     *{box-sizing:border-box;font-family:Inter,ui-sans-serif,system-ui,Segoe UI,Roboto,Arial}
     html,body{margin:0;min-height:100%;background:var(--bg);color:var(--ink)}
     body{position:relative;min-height:100vh;overflow-x:hidden;padding-left:0;transition:padding-left .3s ease}
-    body::before{content:"";position:fixed;inset:-40%;background:radial-gradient(circle at 20% 20%,rgba(242,138,45,.08),rgba(0,0,0,0) 45%),radial-gradient(circle at 80% 10%,rgba(125,211,252,.06),rgba(0,0,0,0) 52%),radial-gradient(circle at 30% 80%,rgba(22,242,166,.04),rgba(0,0,0,0) 55%);pointer-events:none;z-index:-1;filter:blur(0px)}
+    body::before{
+      content:"";
+      position:fixed;
+      inset:-40%;
+      background:
+        linear-gradient(rgba(0,0,0,.78),rgba(0,0,0,.78)),
+        url("https://images.unsplash.com/photo-1524230572899-a752b3835840?auto=format&fit=crop&w=1600&q=80") center/cover no-repeat fixed;
+      pointer-events:none;
+      z-index:-1;
+      filter:blur(12px);
+      transform:scale(1.06);
+    }
     body.theme-light{
       color-scheme:light;
       --bg:#f8fafc; --ink:#0f172a; --ink-soft:#1e293b; --muted:#475569;
@@ -92,6 +103,8 @@
       background:radial-gradient(circle at 20% 20%,rgba(59,130,246,.15),rgba(148,163,184,0) 45%),
                  radial-gradient(circle at 80% 10%,rgba(16,185,129,.12),rgba(148,163,184,0) 52%),
                  radial-gradient(circle at 30% 80%,rgba(249,115,22,.12),rgba(148,163,184,0) 55%);
+      filter:none;
+      transform:none;
     }
     a{color:inherit}
 


### PR DESCRIPTION
## Summary
- replace the dark theme background gradients with a blurred photographic image under a dark overlay
- keep the existing light theme gradients while removing blur/transform for clarity

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d0a4cb3e608326b3c868e965051a2c