### PR TITLE
Reemplaza hero brand por versión minimalista

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,7 @@
       filter:none;
       transform:none;
     }
+    body.theme-light .hero-brand{background:#f4f7f6;color:#0f2f1f;box-shadow:0 14px 32px rgba(15,23,42,.12)}
     a{color:inherit}
 
     body.sidebar-expanded{padding-left:260px}
@@ -151,11 +152,12 @@
       #AppGrid{grid-template-columns:minmax(0,2fr)minmax(0,1fr);grid-template-areas:"form acciones" "tabla tabla";}
     }
     .pill{display:block;width:max-content;margin:0 auto 14px;padding:6px 14px;border-radius:999px;background:var(--pill-bg);color:var(--pill-ink);border:1px solid var(--border);font-size:12px;letter-spacing:.08em;text-transform:uppercase}
-    .hero-brand{display:flex;align-items:center;justify-content:center;flex-wrap:wrap;gap:clamp(12px,3vw,28px);margin:6px 0 24px;text-align:center}
-    .hero-brand img{width:clamp(64px,16vw,132px);height:auto;flex-shrink:0;filter:drop-shadow(0 18px 36px rgba(0,0,0,.55));border-radius:24px}
-    .hero-brand span{display:block;font-weight:800;letter-spacing:-0.02em;color:var(--ink);font-size:clamp(54px,16vw,144px);line-height:.95;text-shadow:0 12px 32px rgba(0,0,0,.55);text-transform:uppercase}
+    .hero-brand{display:flex;align-items:center;justify-content:center;gap:clamp(12px,4vw,32px);margin:12px auto 32px;padding:clamp(16px,4vw,32px) clamp(22px,6vw,48px);border-radius:48px;text-align:center;background:rgba(241,245,243,.92);color:#0f2f1f;box-shadow:0 22px 44px rgba(0,0,0,.45)}
+    .hero-brand img{width:clamp(56px,16vw,128px);height:auto;flex-shrink:0;filter:none}
+    .hero-brand span{display:block;font-weight:600;letter-spacing:-0.04em;font-size:clamp(38px,14vw,112px);line-height:1;text-shadow:none;text-transform:none}
     @media(max-width:520px){
-      .hero-brand span{font-size:clamp(42px,20vw,96px)}
+      .hero-brand{padding:18px 28px}
+      .hero-brand span{font-size:clamp(32px,18vw,72px)}
     }
 
     /* ===== Servicio centrado ===== */
@@ -379,7 +381,7 @@
   <header id="Header">
     <span class="pill">importante</span>
     <div class="hero-brand" role="heading" aria-level="1">
-      <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 120 120'%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0%25' y1='0%25' x2='100%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%237dd3fc'/%3E%3Cstop offset='55%25' stop-color='%2316f2a6'/%3E%3Cstop offset='100%25' stop-color='%23f28a2d'/%3E%3C/linearGradient%3E%3C/defs%3E%3Cpath fill='url(%23g)' d='M98.7 22.3C70.8 12.7 38.5 18.4 22.9 41.3 7.3 64.1 6.9 96 33 96c23.2 0 46.4-23.4 57.4-48.6 5.5-12.7 7.7-23.5 8.3-25.1Z'/%3E%3Cpath fill='none' stroke='rgba(255,255,255,0.6)' stroke-width='6' stroke-linecap='round' d='M36 74c16-8 36-28 47-50'/%3E%3C/svg%3E" alt="Hoja Super Zylo" loading="lazy"/>
+      <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Cpath fill='%230f2f1f' d='M54 6C32 6 10 24 10 46c0 5.6 1.2 10.5 3.3 14.5 15.4-1.7 27.5-9.1 36.5-21.2C55.7 29.5 58.8 20.3 60 9.5 58.5 7 56.5 6.1 54 6z'/%3E%3Cpath fill='none' stroke='%230f2f1f' stroke-width='4' stroke-linecap='round' stroke-linejoin='round' d='M20 46c10-6 22-18 30-32'/%3E%3C/svg%3E" alt="Hoja Super Zylo" loading="lazy"/>
       <span>Super Zylo</span>
     </div>
   </header>


### PR DESCRIPTION
## Summary
- sustituye la imagen degradada de la marca por un icono de hoja minimalista
- ajusta la tipografía y el contenedor de la cabecera para reflejar el estilo simple solicitado

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68d1df7a2aa88326b5ef91d6cd975909