### PR TITLE
Add scroll fade animations to hero and sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,12 @@
     *{box-sizing:border-box;font-family:Inter,ui-sans-serif,system-ui,Segoe UI,Roboto,Arial}
     html,body{margin:0;min-height:100%;background:var(--bg);color:var(--ink)}
     body{position:relative;min-height:100vh;overflow-x:hidden;padding-left:0;transition:padding-left .3s ease}
+    .scroll-fade{will-change:opacity,transform}
+    body.scroll-animations-ready .scroll-fade{opacity:0;transform:translateY(36px);transition:opacity .7s ease,transform .7s ease}
+    body.scroll-animations-ready .scroll-fade.is-visible{opacity:1;transform:none}
+    @media(prefers-reduced-motion:reduce){
+      body.scroll-animations-ready .scroll-fade{opacity:1;transform:none;transition:none}
+    }
     body::before{
       content:"";
       position:fixed;
@@ -378,7 +384,7 @@
     </div>
   </aside>
 
-  <header id="Header">
+  <header id="Header" class="scroll-fade">
     <span class="pill">importante</span>
     <div class="hero-brand" role="heading" aria-level="1">
       <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Cpath fill='%230f2f1f' d='M54 6C32 6 10 24 10 46c0 5.6 1.2 10.5 3.3 14.5 15.4-1.7 27.5-9.1 36.5-21.2C55.7 29.5 58.8 20.3 60 9.5 58.5 7 56.5 6.1 54 6z'/%3E%3Cpath fill='none' stroke='%230f2f1f' stroke-width='4' stroke-linecap='round' stroke-linejoin='round' d='M20 46c10-6 22-18 30-32'/%3E%3C/svg%3E" alt="Hoja Super Zylo" loading="lazy"/>
@@ -386,7 +392,7 @@
     </div>
   </header>
 
-  <section id="BarraServicio" class="center">
+  <section id="BarraServicio" class="center scroll-fade">
     <div class="label">Servicio</div>
     <select id="servicio" style="max-width:260px"></select>
     <button id="btnAgregarServicio" class="addserv" aria-label="Agregar servicio" title="Agregar servicio">+</button>
@@ -394,7 +400,7 @@
   </section>
 
   <main id="AppGrid">
-    <section id="Formulario" class="form">
+    <section id="Formulario" class="form scroll-fade">
       <div class="form-grid">
         <div class="row">
           <label for="nombre">Nombre</label>
@@ -444,7 +450,7 @@
       </div>
     </section>
 
-    <aside id="AccionesRapidas" class="side-card">
+    <aside id="AccionesRapidas" class="side-card scroll-fade">
       <h2>Acciones rápidas</h2>
       <p>Guarda el nuevo cliente o limpia el formulario antes de continuar.</p>
       <div class="actions">
@@ -455,7 +461,7 @@
     </aside>
 
     <!-- tabla -->
-    <section id="TablaClientes" class="table-section">
+    <section id="TablaClientes" class="table-section scroll-fade">
       <div class="table-header">
         <h2 id="clientesTitulo">Clientes registrados</h2>
         <p>Consulta el listado completo y gestiona cada registro.</p>
@@ -616,6 +622,67 @@ const linkedEmailDropdownToggle = document.getElementById('linkedEmailDropdownTo
 let linkedFilteredSuggestions=[];
 let linkedActiveIndex=-1;
 let linkedHideTimeout=null;
+
+/* ===== Animaciones scroll ===== */
+function setupScrollFade(){
+  const targets = Array.from(document.querySelectorAll('.scroll-fade'));
+  if(!targets.length) return;
+
+  document.body.classList.add('scroll-animations-ready');
+
+  if(!('IntersectionObserver' in window)){
+    targets.forEach(el=> el.classList.add('is-visible'));
+    return;
+  }
+
+  const reduceMotionQuery = window.matchMedia ? window.matchMedia('(prefers-reduced-motion: reduce)') : null;
+  let observer = null;
+
+  const ensureObserver = ()=>{
+    if(observer) return;
+    observer = new IntersectionObserver((entries)=>{
+      entries.forEach(entry=>{
+        if(entry.isIntersecting){
+          entry.target.classList.add('is-visible');
+        }else{
+          entry.target.classList.remove('is-visible');
+        }
+      });
+    }, { threshold:0.18, rootMargin:'0px 0px -12% 0px' });
+    targets.forEach(el=>{
+      el.classList.remove('is-visible');
+      observer.observe(el);
+    });
+  };
+
+  const teardownObserver = ()=>{
+    if(observer){ observer.disconnect(); observer=null; }
+    targets.forEach(el=> el.classList.add('is-visible'));
+  };
+
+  const evaluate = ()=>{
+    if(reduceMotionQuery && reduceMotionQuery.matches){
+      teardownObserver();
+    }else{
+      ensureObserver();
+      requestAnimationFrame(()=>{
+        targets.forEach(el=>{
+          const rect = el.getBoundingClientRect();
+          const inView = rect.top < window.innerHeight && rect.bottom > 0;
+          if(inView) el.classList.add('is-visible');
+        });
+      });
+    }
+  };
+
+  evaluate();
+  if(reduceMotionQuery){
+    const listener = () => evaluate();
+    if(reduceMotionQuery.addEventListener){ reduceMotionQuery.addEventListener('change', listener); }
+    else if(reduceMotionQuery.addListener){ reduceMotionQuery.addListener(listener); }
+  }
+}
+setupScrollFade();
 
 function toast(t){ msg.textContent=t; setTimeout(()=>msg.textContent='',2200); }
 function esc(s){return (s||'').replace(/[&<>"']/g,m=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#039;' }[m]))}


### PR DESCRIPTION
## Summary
- add reusable scroll fade styles and respect reduced-motion preferences
- observe hero and main sections to animate visibility on scroll
- tag hero and key sections with scroll-fade class for new transitions

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d1e0c14c90832682c94197a4a8f668