### PR TITLE
Simplifica hero brand a texto ZYLO

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,7 @@
       filter:none;
       transform:none;
     }
+    body.theme-light .hero-brand{color:#0f2f1f}
     a{color:inherit}
 
     body.sidebar-expanded{padding-left:260px}
@@ -151,11 +152,9 @@
       #AppGrid{grid-template-columns:minmax(0,2fr)minmax(0,1fr);grid-template-areas:"form acciones" "tabla tabla";}
     }
     .pill{display:block;width:max-content;margin:0 auto 14px;padding:6px 14px;border-radius:999px;background:var(--pill-bg);color:var(--pill-ink);border:1px solid var(--border);font-size:12px;letter-spacing:.08em;text-transform:uppercase}
-    .hero-brand{display:flex;align-items:center;justify-content:center;flex-wrap:wrap;gap:clamp(12px,3vw,28px);margin:6px 0 24px;text-align:center}
-    .hero-brand img{width:clamp(64px,16vw,132px);height:auto;flex-shrink:0;filter:drop-shadow(0 18px 36px rgba(0,0,0,.55));border-radius:24px}
-    .hero-brand span{display:block;font-weight:800;letter-spacing:-0.02em;color:var(--ink);font-size:clamp(54px,16vw,144px);line-height:.95;text-shadow:0 12px 32px rgba(0,0,0,.55);text-transform:uppercase}
+    .hero-brand{margin:12px 0 32px;font-weight:600;letter-spacing:-0.04em;font-size:clamp(38px,14vw,112px);line-height:1;text-transform:uppercase;text-align:center;color:#ecf4f1;text-shadow:none}
     @media(max-width:520px){
-      .hero-brand span{font-size:clamp(42px,20vw,96px)}
+      .hero-brand{font-size:clamp(32px,18vw,72px)}
     }
 
     /* ===== Servicio centrado ===== */
@@ -378,10 +377,7 @@
 
   <header id="Header">
     <span class="pill">importante</span>
-    <div class="hero-brand" role="heading" aria-level="1">
-      <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 120 120'%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0%25' y1='0%25' x2='100%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%237dd3fc'/%3E%3Cstop offset='55%25' stop-color='%2316f2a6'/%3E%3Cstop offset='100%25' stop-color='%23f28a2d'/%3E%3C/linearGradient%3E%3C/defs%3E%3Cpath fill='url(%23g)' d='M98.7 22.3C70.8 12.7 38.5 18.4 22.9 41.3 7.3 64.1 6.9 96 33 96c23.2 0 46.4-23.4 57.4-48.6 5.5-12.7 7.7-23.5 8.3-25.1Z'/%3E%3Cpath fill='none' stroke='rgba(255,255,255,0.6)' stroke-width='6' stroke-linecap='round' d='M36 74c16-8 36-28 47-50'/%3E%3C/svg%3E" alt="Hoja Super Zylo" loading="lazy"/>
-      <span>Super Zylo</span>
-    </div>
+    <h1 class="hero-brand">ZYLO</h1>
   </header>
 
   <section id="BarraServicio" class="center">


### PR DESCRIPTION
## Summary
- reemplaza el logotipo por el texto plano "ZYLO" sin contenedor decorativo
- ajusta la regla `.hero-brand` para eliminar fondo, icono y mantener tipografía responsiva

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68d1df7a2aa88326b5ef91d6cd975909