### PR TITLE
Improve responsive layout for Admin-Clientes UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,9 +147,9 @@
 
     /* ===== Layout ===== */
     #Header,#BarraServicio,#AppGrid{width:min(1200px,92vw);margin:0 auto}
-    #Header{padding:36px 18px 0;position:relative;z-index:0}
-    #BarraServicio{padding:0 18px}
-    #AppGrid{padding:0 18px 80px;margin-top:32px;display:grid;grid-template-columns:minmax(0,1fr);grid-template-areas:"form" "acciones" "tabla";gap:24px}
+    #Header{padding:36px clamp(16px,4vw,28px) 0;position:relative;z-index:0}
+    #BarraServicio{padding:0 clamp(16px,4vw,28px)}
+    #AppGrid{padding:0 clamp(16px,4vw,28px) 80px;margin-top:32px;display:grid;grid-template-columns:minmax(0,1fr);grid-template-areas:"form" "acciones" "tabla";gap:24px}
     #Formulario{grid-area:form}
     #AccionesRapidas{grid-area:acciones}
     #TablaClientes{grid-area:tabla;margin-top:0}
@@ -163,7 +163,11 @@
     }
 
     /* ===== Servicio centrado ===== */
-    .center{display:flex;justify-content:center;align-items:center;gap:10px;margin:8px 0 20px}
+    .center{display:flex;justify-content:center;align-items:center;gap:10px;margin:8px 0 20px;flex-wrap:wrap}
+    .center > *{flex:1 1 auto;min-width:140px}
+    .center .label{flex:0 0 auto}
+    .center select{flex:1 1 240px;min-width:180px}
+    .center button{flex:0 0 auto}
     .center .label{color:var(--ink-soft)}
     .addserv{border:1px dashed rgba(255,255,255,.26);background:rgba(255,255,255,.04);color:var(--ink);padding:8px 12px;border-radius:12px;font-size:15px;min-width:40px;text-align:center;transition:background-color .2s ease,border-color .2s ease,box-shadow .2s ease,transform .2s ease,color .2s ease}
     .addserv:hover,.addserv:focus-visible{background:rgba(242,138,45,.16);border-color:rgba(242,138,45,.4);box-shadow:0 10px 24px rgba(5,9,15,.4);transform:translateY(-1px)}
@@ -185,7 +189,8 @@
     input::placeholder,textarea::placeholder{color:var(--muted)}
     input:focus,select:focus,textarea:focus{border-color:var(--input-focus-border);background:var(--field-focus);box-shadow:0 0 0 3px var(--input-focus-shadow)}
     textarea{min-height:88px;resize:vertical}
-    .actions{display:flex;justify-content:center;gap:10px;margin-top:18px}
+    .actions{display:flex;justify-content:center;gap:10px;margin-top:18px;flex-wrap:wrap}
+    .actions .btn{flex:1 1 140px}
     .small{font-size:12px;color:var(--muted);text-align:center;margin-top:8px}
     .side-card{background:var(--card-bg);border-radius:20px;border:1px solid var(--border);padding:28px;box-shadow:var(--shadow);backdrop-filter:blur(22px);display:flex;flex-direction:column;gap:18px}
     .side-card h2{margin:0;font-size:18px;color:var(--ink);font-weight:700}
@@ -321,11 +326,37 @@
     .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
     .menu-item[aria-checked="true"]{background:var(--ghost);border:1px solid var(--ghost-border);font-weight:600}
 
+    @media(max-width:1024px){
+      #Header,#BarraServicio,#AppGrid{width:min(100%,96vw)}
+    }
     @media(max-width:960px){ body.sidebar-expanded{padding-left:0} }
+    @media(max-width:820px){
+      #AppGrid{gap:20px;padding-bottom:60px}
+      .side-card{padding:24px}
+    }
     @media(max-width:768px){
       .sidebar{box-shadow:0 0 0 rgba(0,0,0,0)}
       .sidebar.pinned,.sidebar.peek{box-shadow:20px 0 40px rgba(0,0,0,.35)}
       body.sidebar-expanded .sidebar-launcher{left:20px}
+      .side-card .actions{flex-direction:column}
+      .side-card .actions .btn{width:100%}
+    }
+    @media(max-width:640px){
+      .form,.side-card{padding:22px 18px}
+      .actions{flex-direction:column}
+      .actions .btn{width:100%;flex:1 1 auto}
+      .center{gap:12px}
+      .center .label{width:100%;text-align:center}
+      .center > *{flex:1 1 100%;min-width:0}
+      .center button{flex:1 1 48%}
+      .center select{min-width:0}
+      #AppGrid{padding-bottom:48px}
+    }
+    @media(max-width:520px){
+      .sidebar-launcher{width:48px;height:48px}
+      .sidebar{width:min(280px,92vw)}
+      .form,.side-card{padding:20px 16px}
+      .table-card{border-radius:18px}
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- adjust header, service bar and main grid padding with clamp-based values for better scaling on different viewports
- make the service selector and action buttons wrap responsively to prevent overflow on small screens
- introduce additional breakpoints to relax spacing, stack controls and size the sidebar on tablets and phones

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1e77a9dfc8326ba20c7772efa62e7